### PR TITLE
Add websocket to agent-js (subscribed by agent-client-js)

### DIFF
--- a/packages/agent-js/README.md
+++ b/packages/agent-js/README.md
@@ -42,19 +42,21 @@ agent.addProcess("my_first_process", actions, storeHttpClient, fossilizerHttpCli
 });
 
 // Creates an HTTP server for the agent with CORS enabled.
-var agentHttpServer = agent.httpServer({ cors: {} });
+var agentHttpServer = Agent.httpServer(agent, { cors: {} });
 
 // Create the Express server.
-var app = express();
-
+const app = express();
 app.disable('x-powered-by');
 
 // Mount agent on the root path of the server.
 app.use('/', agentHttpServer);
 
-// Start the server.
-app.listen(3000, function() {
-  console.log('Listening on :' + this.address().port);
+// Create server by binding app and websocket connection
+const server = Agent.websocketServer(app, storeHttpClient);
+
+// Start the server
+server.listen(3000, () => {
+  console.log('Listening on ' + server.adress().port);
 });
 
 // You can also add processes on-the-fly after the server has started listening
@@ -69,7 +71,8 @@ agent.addProcess("my_second_process", actions, storeHttpClient, fossilizerHttpCl
 - `create` creates an agent instance.
 - `storeHttpClient` creates an instance to work with stores via HTTP.
 - `fossilizerHttpClient` creates an instance to work with fossilizers via HTTP.
-- `httpServer` creates an HTTP server for an agent.
+- `httpServer` creates an app for the agent
+- `websocketServer`bind websocket connection to app and returns server
 
 ## Plugins
 

--- a/packages/agent-js/src/index.js
+++ b/packages/agent-js/src/index.js
@@ -20,6 +20,7 @@ import httpServer from './httpServer';
 import memoryStore from './memoryStore';
 import plugins from './plugins';
 import storeHttpClient from './storeHttpClient';
+import websocketServer from './websocketServer';
 
 module.exports = {
   create,
@@ -28,4 +29,5 @@ module.exports = {
   memoryStore,
   plugins,
   storeHttpClient,
+  websocketServer,
 };

--- a/packages/agent-js/src/websocketServer.js
+++ b/packages/agent-js/src/websocketServer.js
@@ -1,0 +1,42 @@
+/*
+  Copyright 2017 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import http from 'http';
+import websocket from 'ws';
+
+/**
+ * Adds websocket to httpServer
+ * @param {object} [httpServer] - http server
+ * @param {object} [storeHttpClient] - agent store http client
+ * @returns {object} - a server
+ */
+export default function websocketServer(app, storeHttpClient) {
+  const server = http.createServer(app);
+  const wss = new websocket.Server({ server });
+
+  // Send messages on storeHttpClient message event
+  storeHttpClient.on('message', (msg) => {
+    const msgJson = JSON.stringify(msg);
+    wss.clients.forEach((client) => {
+      client.send(msgJson);
+    });
+  });
+  wss.on('connection', (ws) => {
+    ws.send('Connected to agent client websocket');
+  });
+
+  return server;
+}


### PR DESCRIPTION
Creates a websocket for agent-client-js on ws://localhost:3000 when http server is started. storeHttpClient events are propagated to web socket.

Use `const server = Agent.listen(agent, storeHttpClient)` to start server and websocket.

TODO: Implementation on agent-client-js