### PR TITLE
agent-client-js: use qs for querystring encoding to handle arrays

### DIFF
--- a/packages/agent-client-js/package.json
+++ b/packages/agent-client-js/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "httpplease": "^0.16.4",
+    "qs": "^6.5.1",
     "setimmediate": "^1.0.5",
     "xmlhttprequest": "~1.7.0"
   }

--- a/packages/agent-client-js/src/makeQueryString.js
+++ b/packages/agent-client-js/src/makeQueryString.js
@@ -21,7 +21,11 @@ import { stringify } from 'qs';
  * @returns {string} a query string
  */
 export default function makeQueryString(obj) {
-  const query = stringify(obj);
+  // use brackets format for compatibility with GO:
+  // https://github.com/google/go-querystring
+  // see also conversation in:
+  // https://github.com/stratumn/indigo-js/pull/18
+  const query = stringify(obj, { arrayFormat: 'brackets' });
   if (query.length) {
     return `?${query}`;
   }

--- a/packages/agent-client-js/src/makeQueryString.js
+++ b/packages/agent-client-js/src/makeQueryString.js
@@ -13,6 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+import { stringify } from 'qs';
 
 /**
  * Makes a query string.
@@ -20,15 +21,9 @@
  * @returns {string} a query string
  */
 export default function makeQueryString(obj) {
-  const parts = Object.keys(obj).reduce((curr, key) => {
-    const val = Array.isArray(obj[key]) ? obj[key].join('+') : obj[key];
-    curr.push(`${encodeURIComponent(key)}=${encodeURIComponent(val)}`);
-    return curr;
-  }, []);
-
-  if (parts.length) {
-    return `?${parts.join('&')}`;
+  const query = stringify(obj);
+  if (query.length) {
+    return `?${query}`;
   }
-
   return '';
 }

--- a/packages/agent-client-js/test/findSegments.js
+++ b/packages/agent-client-js/test/findSegments.js
@@ -36,12 +36,16 @@ describe('#findSegments', () => {
         .then(() => processCb().createMap('hi'))
         .then(segment => segment.addMessage('hello', 'bob'))
         .then(segment => segment.addTag('myTag'))
+        .then(segment => segment.addTag('myTag2'))
+        .then(() => processCb().findSegments({ tags: ['myTag', 'myTag2'] }))
+        .then(segments => {
+          segments.should.be.an.Array();
+          segments.length.should.be.exactly(1);
+        })
         .then(() => processCb().findSegments({ tags: ['myTag'] }))
         .then(segments => {
           segments.should.be.an.Array();
-          // below does not work due to a bug in findSegments with tags..
-          // segments.length.should.be.exactly(1);
-          segments.length.should.be.oneOf(0, 1);
+          segments.length.should.be.exactly(2);
         })
     );
 


### PR DESCRIPTION
https://github.com/stratumn/indigo-js/issues/17

use node library qs to encode query strings which is also used by express extended query parser to decode query strings. See: http://expressjs.com/en/api.html