### PR TITLE
agent-js: use brackets for query arrays

### DIFF
--- a/packages/agent-js/package.json
+++ b/packages/agent-js/package.json
@@ -36,6 +36,7 @@
     "canonical-json": "0.0.4",
     "cors": "^2.7.1",
     "express": "^4.14.0",
+    "qs": "^6.5.1",
     "request": "^2.73.0",
     "stratumn-mock-agent": "^1.2.0",
     "superagent": "^2.1.0",

--- a/packages/agent-js/src/makeQueryString.js
+++ b/packages/agent-js/src/makeQueryString.js
@@ -14,21 +14,21 @@
   limitations under the License.
 */
 
+import { stringify } from 'qs';
+
 /**
  * Makes a query string.
  * @param {object} obj - an object of keys
  * @returns {string} a query string
  */
 export default function makeQueryString(obj) {
-  const parts = Object.keys(obj).reduce((curr, key) => {
-    const val = Array.isArray(obj[key]) ? obj[key].join('+') : obj[key];
-    curr.push(`${encodeURIComponent(key)}=${encodeURIComponent(val)}`);
-    return curr;
-  }, []);
-
-  if (parts.length) {
-    return `?${parts.join('&')}`;
+  // use brackets format for compatibility with GO:
+  // https://github.com/google/go-querystring
+  // see also conversation in:
+  // https://github.com/stratumn/indigo-js/pull/18
+  const query = stringify(obj, { arrayFormat: 'brackets' });
+  if (query.length) {
+    return `?${query}`;
   }
-
   return '';
 }

--- a/packages/agent-js/test/makeQueryString.js
+++ b/packages/agent-js/test/makeQueryString.js
@@ -25,7 +25,7 @@ describe('#makeQueryString()', () => {
     makeQueryString({}).should.be.exactly('');
   });
 
-  it('joins array elements with a comma', () => {
-    makeQueryString({ a: [1, 2, 'three'] }).should.be.exactly('?a=1%2B2%2Bthree');
+  it('uses bracket convention for arrays', () => {
+    makeQueryString({ a: [1, 2, 'three'] }).should.be.exactly('?a%5B%5D=1&a%5B%5D=2&a%5B%5D=three');
   });
 });

--- a/packages/agent-js/test/storeHttpClient.js
+++ b/packages/agent-js/test/storeHttpClient.js
@@ -114,7 +114,8 @@ describe('StoreHttpClient', () => {
           body.should.be.an.Array();
           body.length.should.be.exactly(1);
           body[0].link.state.query.should.be.exactly(
-            'process=one&mapId=map&prevLinkHash=hash&tags=tag1%2Btag2&offset=20&limit=10');
+            'process=one&mapId=map&prevLinkHash=hash' +
+            '&tags%5B%5D=tag1&tags%5B%5D=tag2&offset=20&limit=10');
         })
     );
 


### PR DESCRIPTION
`storeHttpClient` will now use brackets when making requests to the store
that contain arrays in the query string.

For example:

    GET /segments?mapIds[]=id1&mapIds[]=id2&tags[]=t1&tags[]=t2