### PR TITLE
agent-ui: add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 lerna-debug.log
+
+# dependencies
+node_modules/


### PR DESCRIPTION
since root level has its own dev deps, we should ignore node_modules/ folder