### PR TITLE
agent-ui: add the process info page

### DIFF
--- a/packages/agent-ui/src/components/agentInfoPage.js
+++ b/packages/agent-ui/src/components/agentInfoPage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-class AgentInfoPage extends Component {
+export class AgentInfoPage extends Component {
   render() {
     return (
       <div>

--- a/packages/agent-ui/src/components/app.js
+++ b/packages/agent-ui/src/components/app.js
@@ -5,14 +5,8 @@ import { connect } from 'react-redux';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 import { TopBar, LeftDrawer } from './';
-import { getAgentInfo } from '../actions';
 
 class App extends Component {
-  componentDidMount() {
-    const { dispatch } = this.props;
-    dispatch(getAgentInfo());
-  }
-
   render() {
     console.log('App render', this.props);
     return (

--- a/packages/agent-ui/src/components/index.js
+++ b/packages/agent-ui/src/components/index.js
@@ -2,3 +2,4 @@ export { default as App } from './app';
 export { default as LeftDrawer } from './leftDrawer';
 export { default as TopBar } from './topBar';
 export { default as AgentInfoPage } from './agentInfoPage';
+export { default as ProcessInfoPage } from './processInfoPage';

--- a/packages/agent-ui/src/components/processInfoPage.js
+++ b/packages/agent-ui/src/components/processInfoPage.js
@@ -1,0 +1,144 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+export class ProcessInfoPage extends Component {
+  render() {
+    const process = this.props.process;
+    if (!process || !process.name) {
+      return <div>Loading...</div>;
+    }
+
+    return (
+      <div>
+        <h1>{process.name}</h1>
+        <ActionsSection actions={process.processInfo.actions} />
+        <hr />
+        <StoreSection storeAdapter={process.storeInfo.adapter} />
+        <hr />
+        <FossilizersSection fossilizers={process.fossilizersInfo} />
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  let process = {};
+  if (state.agentInfo) {
+    if (state.agentInfo.processes[ownProps.params.process]) {
+      process = state.agentInfo.processes[ownProps.params.process];
+    }
+  }
+  return { process };
+}
+
+ProcessInfoPage.propTypes = {
+  process: PropTypes.object.isRequired
+};
+
+export const StoreSection = ({ storeAdapter }) => (
+  <div>
+    <h3>Store</h3>
+    <p>
+      <small>
+        A store is responsible for saving your data. There are different
+        adapters available depending on your needs.
+      </small>
+    </p>
+    <h4>Store adapter name</h4>
+    <samp>{storeAdapter.name}</samp>
+    <h4>Store adapter version</h4>
+    <samp>{storeAdapter.version}</samp>
+    <h4>Store adapter commit</h4>
+    <samp>{storeAdapter.commit}</samp>
+    <h4>Store adapter description</h4>
+    <samp>{storeAdapter.description}</samp>
+  </div>
+);
+
+StoreSection.propTypes = {
+  storeAdapter: PropTypes.object.isRequired
+};
+
+function formatActionSignature(action, args) {
+  let signature = action + '(';
+  for (let i = 0; args && i < args.length; ++i) {
+    signature += args[i];
+    if (i < args.length - 1) {
+      signature += ', ';
+    }
+  }
+  signature += ')';
+  return signature;
+}
+
+export const ActionsSection = ({ actions }) => (
+  <div>
+    <h3>Actions</h3>
+    <ul>
+      {Object.keys(actions).map(action => (
+        <li key={action}>
+          <samp>{formatActionSignature(action, actions[action].args)}</samp>
+        </li>
+      ))}
+    </ul>
+    <p>
+      <small>
+        These are the procedures that define how segments are added to your
+        maps.
+      </small>
+    </p>
+  </div>
+);
+
+ActionsSection.propTypes = {
+  actions: PropTypes.object
+};
+
+export const FossilizersSection = ({ fossilizers }) => (
+  <div>
+    <h3>Fossilizer</h3>
+    <p>
+      <small>
+        A fossilizer adds the steps of your workflow to a timeline, such as a
+        Blockchain or a trusted timestamping authority.
+      </small>
+    </p>
+    {!fossilizers && <p>Your agent is not connected to fossilizers.</p>}
+    {fossilizers &&
+      fossilizers.length && (
+        <ul>
+          {fossilizers.map(fossilizer => (
+            <li key={fossilizer.adapter.name}>
+              <h4>
+                Fossilizer:
+                <samp>{fossilizer.adapter.name}</samp>
+              </h4>
+              <h4>
+                Adapter version:
+                <samp>{fossilizer.adapter.version}</samp>
+              </h4>
+              <h4>
+                Adapter commit:
+                <samp>{fossilizer.adapter.commit}</samp>
+              </h4>
+              <h4>
+                Adapter description:
+                <samp>{fossilizer.adapter.description}</samp>
+              </h4>
+              <h4>
+                Adapter blockchain
+                <samp>{fossilizer.adapter.blockchain}</samp>
+              </h4>
+            </li>
+          ))}
+        </ul>
+      )}
+  </div>
+);
+
+FossilizersSection.propTypes = {
+  fossilizers: PropTypes.array
+};
+
+export default connect(mapStateToProps)(ProcessInfoPage);

--- a/packages/agent-ui/src/routes.js
+++ b/packages/agent-ui/src/routes.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Route, IndexRoute } from 'react-router';
 
-import App from './components/app';
-import AgentInfoPage from './components/agentInfoPage';
+import { App, AgentInfoPage, ProcessInfoPage } from './components';
 
 export default (
   <Route path="/" component={App}>
     <IndexRoute component={AgentInfoPage} />
+    <Route path=":process" component={ProcessInfoPage} />
   </Route>
 );

--- a/packages/agent-ui/src/setupTests.js
+++ b/packages/agent-ui/src/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });

--- a/packages/agent-ui/src/store/dom.js
+++ b/packages/agent-ui/src/store/dom.js
@@ -5,12 +5,16 @@ import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 
+import { getAgentInfo } from '../actions';
 import routes from '../routes';
 import { configureStore } from './';
 
 export default function(doc) {
   const store = configureStore();
+  store.dispatch(getAgentInfo());
+
   const history = syncHistoryWithStore(browserHistory, store);
+
   ReactDOM.render(
     <Provider store={store}>
       <Router history={history} routes={routes} />

--- a/packages/agent-ui/src/test/components/agentInfoPage.test.js
+++ b/packages/agent-ui/src/test/components/agentInfoPage.test.js
@@ -1,52 +1,22 @@
 import React from 'react';
-import { Provider } from 'react-redux';
 
-import { configure, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
+import { mount } from 'enzyme';
 import { expect } from 'chai';
 
-import { AgentInfoPage } from '../../components';
-import { actionTypes } from '../../actions';
-import configureStore from '../../store/configure';
+import { AgentInfoPage } from '../../components/agentInfoPage';
 
 describe('<AgentInfoPage />', () => {
-  configure({ adapter: new Adapter() });
-
-  let props;
-  let mountedAgentInfoPage;
-  const testStore = configureStore();
-
-  const agentInfoPage = () => {
-    if (!mountedAgentInfoPage) {
-      mountedAgentInfoPage = mount(
-        <Provider store={testStore}>
-          <AgentInfoPage {...props} />
-        </Provider>
-      );
-    }
-
-    return mountedAgentInfoPage;
-  };
-
-  beforeEach(() => {
-    props = {};
-    mountedAgentInfoPage = undefined;
-  });
-
   it('always renders a div', () => {
-    const divs = agentInfoPage().find('div');
+    const agentInfoPage = mount(<AgentInfoPage agentUrl="ignored" />);
+    const divs = agentInfoPage.find('div');
     expect(divs).to.have.lengthOf.above(0);
   });
 
   it('receives the agent url from the store', () => {
-    testStore.dispatch({
-      type: actionTypes.AGENT_INFO_SUCCESS,
-      info: { url: 'http://localhost:3000' }
-    });
-
-    const links = agentInfoPage().find('a');
-
+    const agentInfoPage = mount(
+      <AgentInfoPage agentUrl="http://localhost:3000" />
+    );
+    const links = agentInfoPage.find('a');
     expect(
       links.filterWhere(link => link.prop('href') === 'http://localhost:3000')
     ).to.have.lengthOf.above(0);

--- a/packages/agent-ui/src/test/components/processInfoPage.test.js
+++ b/packages/agent-ui/src/test/components/processInfoPage.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import {
+  ProcessInfoPage,
+  StoreSection,
+  ActionsSection,
+  FossilizersSection
+} from '../../components/processInfoPage';
+
+describe('<ProcessInfoPage />', () => {
+  const testProcess = {
+    name: 'test',
+    processInfo: {
+      actions: { init: { args: ['message'] } }
+    },
+    storeInfo: {
+      adapter: {}
+    }
+  };
+
+  it('renders a loading message while process info has not loaded', () => {
+    const processInfoPage = mount(<ProcessInfoPage />);
+    const loadingDiv = processInfoPage.find('div');
+    expect(loadingDiv).to.have.length(1);
+    expect(loadingDiv.text()).to.equal('Loading...');
+  });
+
+  it('displays the process name once loaded', () => {
+    const processInfoPage = mount(<ProcessInfoPage process={testProcess} />);
+    expect(processInfoPage.find('h1').text()).to.equal('test');
+  });
+
+  it('renders actions details and forwards properties', () => {
+    const processInfoPage = mount(<ProcessInfoPage process={testProcess} />);
+    expect(processInfoPage.find(ActionsSection)).to.have.length(1);
+    expect(processInfoPage.find(ActionsSection).props().actions).to.deep.equal(
+      testProcess.processInfo.actions
+    );
+  });
+
+  it('renders store details and forwards properties', () => {
+    const processInfoPage = mount(<ProcessInfoPage process={testProcess} />);
+    expect(processInfoPage.find(StoreSection)).to.have.length(1);
+    expect(
+      processInfoPage.find(StoreSection).props().storeAdapter
+    ).to.deep.equal(testProcess.storeInfo.adapter);
+  });
+
+  it('renders fossilizers details and forwards properties', () => {
+    const processInfoPage = mount(<ProcessInfoPage process={testProcess} />);
+    expect(processInfoPage.find(FossilizersSection)).to.have.length(1);
+    expect(
+      processInfoPage.find(FossilizersSection).props().fossilizers
+    ).to.deep.equal(testProcess.fossilizersInfo);
+  });
+});


### PR DESCRIPTION
Also in this PR:
* changed a bit the way we test components based on community best practices: I was previously kind of testing that redux worked well (using the store to dispatch props) whereas I can simplify this by testing only the components in isolation and trust that redux works
* moved the call to get agent info to the initialization (otherwise it wasn't executed when a user directly goes to a process url such as http://localhost:4000/myprocess)

Not in this PR but will come in a separate one:
* I'll add some tests for mapStateToProps
* I'll test the sub-components of the process info page (StoreSection, ActionsSection, FossilizersSection)