### PR TITLE
ci: fix lint tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "bootstrap": "lerna bootstrap",
     "clean":
       "find packages -type d -name 'node_modules' -maxdepth 2 -exec rm -R {} \\;",
-    "lint": "eslint packages/*/src/** packages/*/test/**",
-    "lint:ci": "eslint packages/$PACKAGE/src/** packages/$PACKAGE/test/**",
+    "lint": "eslint packages/*/src packages/*/test",
+    "lint:ci":
+      "lerna exec --scope $PACKAGE -- \\$LERNA_ROOT_PATH/node_modules/.bin/eslint \\$\\(pwd\\)/src \\$\\(pwd\\)/test",
     "test": "lerna run test:ci",
     "test:ci": "lerna run --scope $PACKAGE test:ci",
     "update-license-headers": "./update-license-headers.sh"

--- a/packages/agent-ui/src/components/agentInfoPage.js
+++ b/packages/agent-ui/src/components/agentInfoPage.js
@@ -1,46 +1,38 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-export class AgentInfoPage extends Component {
-  render() {
-    return (
-      <div>
-        <p>
-          An agent executes the logic of your processes. A process is defined by
-          a set of actions that may be used in the workflow.<br />
-          An instance of a process is called a map. It contains the different
-          steps of the process, called segments.
-        </p>
-        <hr />
-        <h2>Endpoint</h2>
-        <p>
-          <a
-            href={this.props.agentUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {this.props.agentUrl}
-          </a>
-        </p>
-        <p>
-          <small>
-            You can use this URL to connect to your agent, using the{' '}
-            <a
-              href="https://github.com/stratumn/indigo-js/tree/master/packages/agent-client-js"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Stratumn Javascript Agent Client
-            </a>{' '}
-            for instance.
-          </small>
-        </p>
-        <hr />
-      </div>
-    );
-  }
-}
+export const AgentInfoPage = ({ agentUrl }) => (
+  <div>
+    <p>
+      An agent executes the logic of your processes. A process is defined by a
+      set of actions that may be used in the workflow.<br />
+      An instance of a process is called a map. It contains the different steps
+      of the process, called segments.
+    </p>
+    <hr />
+    <h2>Endpoint</h2>
+    <p>
+      <a href={agentUrl} target="_blank" rel="noopener noreferrer">
+        {agentUrl}
+      </a>
+    </p>
+    <p>
+      <small>
+        You can use this URL to connect to your agent, using the{' '}
+        <a
+          href="https://github.com/stratumn/indigo-js/tree/master/packages/agent-client-js"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Stratumn Javascript Agent Client
+        </a>{' '}
+        for instance.
+      </small>
+    </p>
+    <hr />
+  </div>
+);
 
 function mapStateToProps(state) {
   let agentUrl = '';

--- a/packages/agent-ui/src/components/app.js
+++ b/packages/agent-ui/src/components/app.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -6,20 +6,15 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 import { TopBar, LeftDrawer } from './';
 
-class App extends Component {
-  render() {
-    console.log('App render', this.props);
-    return (
-      <MuiThemeProvider>
-        <div>
-          <TopBar />
-          <LeftDrawer processes={this.props.processes} />
-          {this.props.children}
-        </div>
-      </MuiThemeProvider>
-    );
-  }
-}
+export const App = ({ processes, children }) => (
+  <MuiThemeProvider>
+    <div>
+      <TopBar />
+      <LeftDrawer processes={processes} />
+      {children}
+    </div>
+  </MuiThemeProvider>
+);
 
 function mapStateToProps(state) {
   console.log('mapStateToProps', state);
@@ -32,8 +27,7 @@ function mapStateToProps(state) {
 
 App.propTypes = {
   children: PropTypes.node.isRequired,
-  processes: PropTypes.arrayOf(PropTypes.string).isRequired,
-  dispatch: PropTypes.func.isRequired
+  processes: PropTypes.arrayOf(PropTypes.string).isRequired
 };
 
 export default connect(mapStateToProps)(App);

--- a/packages/agent-ui/src/components/app.js
+++ b/packages/agent-ui/src/components/app.js
@@ -31,7 +31,7 @@ function mapStateToProps(state) {
 }
 
 App.propTypes = {
-  children: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
   processes: PropTypes.arrayOf(PropTypes.string).isRequired,
   dispatch: PropTypes.func.isRequired
 };

--- a/packages/agent-ui/src/components/processInfoPage.js
+++ b/packages/agent-ui/src/components/processInfoPage.js
@@ -1,15 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-export class ProcessInfoPage extends Component {
-  render() {
-    const process = this.props.process;
-    if (!process || !process.name) {
-      return <div>Loading...</div>;
-    }
-
-    return (
+export const ProcessInfoPage = ({ process }) => (
+  <div>
+    {!process.name && <p>Loading...</p>}
+    {process.name && (
       <div>
         <h1>{process.name}</h1>
         <ActionsSection actions={process.processInfo.actions} />
@@ -18,9 +14,9 @@ export class ProcessInfoPage extends Component {
         <hr />
         <FossilizersSection fossilizers={process.fossilizersInfo} />
       </div>
-    );
-  }
-}
+    )}
+  </div>
+);
 
 function mapStateToProps(state, ownProps) {
   let process = {};
@@ -32,8 +28,13 @@ function mapStateToProps(state, ownProps) {
   return { process };
 }
 
+ProcessInfoPage.defaultProps = {
+  process: { name: '' }
+};
 ProcessInfoPage.propTypes = {
-  process: PropTypes.object.isRequired
+  process: PropTypes.shape({
+    name: PropTypes.string
+  })
 };
 
 export const StoreSection = ({ storeAdapter }) => (
@@ -57,12 +58,17 @@ export const StoreSection = ({ storeAdapter }) => (
 );
 
 StoreSection.propTypes = {
-  storeAdapter: PropTypes.object.isRequired
+  storeAdapter: PropTypes.shape({
+    name: PropTypes.string,
+    version: PropTypes.string,
+    commit: PropTypes.string,
+    description: PropTypes.string
+  }).isRequired
 };
 
 function formatActionSignature(action, args) {
-  let signature = action + '(';
-  for (let i = 0; args && i < args.length; ++i) {
+  let signature = `${action}(`;
+  for (let i = 0; args && i < args.length; i += 1) {
     signature += args[i];
     if (i < args.length - 1) {
       signature += ', ';
@@ -91,8 +97,15 @@ export const ActionsSection = ({ actions }) => (
   </div>
 );
 
+ActionsSection.defaultProps = {
+  actions: {}
+};
 ActionsSection.propTypes = {
-  actions: PropTypes.object
+  actions: PropTypes.objectOf(
+    PropTypes.shape({
+      args: PropTypes.arrayOf(PropTypes.string)
+    })
+  )
 };
 
 export const FossilizersSection = ({ fossilizers }) => (
@@ -104,41 +117,55 @@ export const FossilizersSection = ({ fossilizers }) => (
         Blockchain or a trusted timestamping authority.
       </small>
     </p>
-    {!fossilizers && <p>Your agent is not connected to fossilizers.</p>}
-    {fossilizers &&
-      fossilizers.length && (
-        <ul>
-          {fossilizers.map(fossilizer => (
-            <li key={fossilizer.adapter.name}>
-              <h4>
-                Fossilizer:
-                <samp>{fossilizer.adapter.name}</samp>
-              </h4>
-              <h4>
-                Adapter version:
-                <samp>{fossilizer.adapter.version}</samp>
-              </h4>
-              <h4>
-                Adapter commit:
-                <samp>{fossilizer.adapter.commit}</samp>
-              </h4>
-              <h4>
-                Adapter description:
-                <samp>{fossilizer.adapter.description}</samp>
-              </h4>
-              <h4>
-                Adapter blockchain
-                <samp>{fossilizer.adapter.blockchain}</samp>
-              </h4>
-            </li>
-          ))}
-        </ul>
-      )}
+    {fossilizers.length === 0 && (
+      <p>Your agent is not connected to fossilizers.</p>
+    )}
+    {fossilizers.length > 0 && (
+      <ul>
+        {fossilizers.map(fossilizer => (
+          <li key={fossilizer.adapter.name}>
+            <h4>
+              Fossilizer:
+              <samp>{fossilizer.adapter.name}</samp>
+            </h4>
+            <h4>
+              Adapter version:
+              <samp>{fossilizer.adapter.version}</samp>
+            </h4>
+            <h4>
+              Adapter commit:
+              <samp>{fossilizer.adapter.commit}</samp>
+            </h4>
+            <h4>
+              Adapter description:
+              <samp>{fossilizer.adapter.description}</samp>
+            </h4>
+            <h4>
+              Adapter blockchain
+              <samp>{fossilizer.adapter.blockchain}</samp>
+            </h4>
+          </li>
+        ))}
+      </ul>
+    )}
   </div>
 );
 
+FossilizersSection.defaultProps = {
+  fossilizers: []
+};
 FossilizersSection.propTypes = {
-  fossilizers: PropTypes.array
+  fossilizers: PropTypes.arrayOf(
+    PropTypes.shape({
+      adapter: {
+        name: PropTypes.string,
+        version: PropTypes.string,
+        commit: PropTypes.string,
+        description: PropTypes.string,
+        blockchain: PropTypes.string
+      }
+    })
+  )
 };
 
 export default connect(mapStateToProps)(ProcessInfoPage);

--- a/packages/agent-ui/src/reducers/index.js
+++ b/packages/agent-ui/src/reducers/index.js
@@ -1,1 +1,3 @@
-export { default as getAgentInfo } from './getAgentInfo';
+/* eslint-disable */
+export { default as getAgentInfo } from "./getAgentInfo";
+/* eslint-enable */

--- a/packages/agent-ui/src/setupTests.js
+++ b/packages/agent-ui/src/setupTests.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/packages/agent-ui/src/test/components/processInfoPage.test.js
+++ b/packages/agent-ui/src/test/components/processInfoPage.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { mount } from 'enzyme';
 import { expect } from 'chai';
@@ -19,7 +18,8 @@ describe('<ProcessInfoPage />', () => {
     },
     storeInfo: {
       adapter: {}
-    }
+    },
+    fossilizersInfo: []
   };
 
   it('renders a loading message while process info has not loaded', () => {


### PR DESCRIPTION
some packages have a different name than the directory they are in and they were missed by the previous lint:ci script.

We could have renamed the directories/package but I think this solution is not too ugly. Let me know what you think.