### PR TITLE
agent-js: track fossilizer and store clients created

### DIFF
--- a/packages/agent-js/src/create.js
+++ b/packages/agent-js/src/create.js
@@ -18,6 +18,9 @@ import httpServer from './httpServer';
 import Process from './process';
 import getDefinedFilters from './getDefinedFilters';
 
+import { getAvailableFossilizers } from './fossilizerHttpClient';
+import { getAvailableStores } from './storeHttpClient';
+
 /**
  * Creates an agent.
  * @param {object} options - options
@@ -98,7 +101,11 @@ export default function create(options) {
             return map;
           }, {})
         )
-        .then(map => ({ processes: map }));
+        .then(map => ({
+          processes: map,
+          stores: getAvailableStores(),
+          fossilizers: getAvailableFossilizers()
+        }));
     },
 
     /**

--- a/packages/agent-js/src/fossilizerHttpClient.js
+++ b/packages/agent-js/src/fossilizerHttpClient.js
@@ -27,9 +27,9 @@ import handleResponse from './handleResponse';
  */
 export default function fossilizerHttpClient(url, opts = {}) {
   if (
-    fossilizerHttpClient.availableFossilizers.filter(
+    !fossilizerHttpClient.availableFossilizers.find(
       fossilizer => fossilizer.url === url
-    ).length === 0
+    )
   ) {
     fossilizerHttpClient.availableFossilizers.push({
       name: opts.name,

--- a/packages/agent-js/src/fossilizerHttpClient.js
+++ b/packages/agent-js/src/fossilizerHttpClient.js
@@ -22,9 +22,21 @@ import handleResponse from './handleResponse';
  * @param {string} url - the base URL of the fossilizer
  * @param {object} [opts] - options
  * @param {function} [opts.callbackUrl] - builds a URL that will be called with the evidence
+ * @param {string} [opts.name] - the name of the fossilizer
  * @returns {Client} a fossilizer HTTP client
  */
 export default function fossilizerHttpClient(url, opts = {}) {
+  if (
+    fossilizerHttpClient.availableFossilizers.filter(
+      fossilizer => fossilizer.url === url
+    ).length === 0
+  ) {
+    fossilizerHttpClient.availableFossilizers.push({
+      name: opts.name,
+      url: url
+    });
+  }
+
   return {
     /**
      * Gets information about the fossilizer.
@@ -69,4 +81,22 @@ export default function fossilizerHttpClient(url, opts = {}) {
       });
     }
   };
+}
+
+fossilizerHttpClient.availableFossilizers = [];
+
+/**
+ * Returns basic information about the fossilizer HTTP clients that have been created.
+ * @returns {Array} an array of fossilizer HTTP clients basic information
+ */
+export function getAvailableFossilizers() {
+  return JSON.parse(JSON.stringify(fossilizerHttpClient.availableFossilizers));
+}
+
+/**
+ * Clears information about the fossilizer HTTP clients created.
+ * Should only be used for tests setup.
+ */
+export function clearAvailableFossilizers() {
+  fossilizerHttpClient.availableFossilizers = [];
 }

--- a/packages/agent-js/src/storeHttpClient.js
+++ b/packages/agent-js/src/storeHttpClient.js
@@ -37,10 +37,7 @@ import filterAsync from './filterAsync';
  * @returns {Client} a store HTTP client
  */
 export default function storeHttpClient(url, opt = {}) {
-  if (
-    storeHttpClient.availableStores.filter(store => store.url === url)
-      .length === 0
-  ) {
+  if (!storeHttpClient.availableStores.find(store => store.url === url)) {
     storeHttpClient.availableStores.push({
       name: opt.name,
       url: url

--- a/packages/agent-js/src/storeHttpClient.js
+++ b/packages/agent-js/src/storeHttpClient.js
@@ -32,9 +32,21 @@ import filterAsync from './filterAsync';
  *   - 'didSave': a segment was saved
  *
  * @param {string} url - the base URL of the store
+ * @param {object} [opt] - options
+ * @param {string} [opt.name] - the name of the store
  * @returns {Client} a store HTTP client
  */
-export default function storeHttpClient(url) {
+export default function storeHttpClient(url, opt = {}) {
+  if (
+    storeHttpClient.availableStores.filter(store => store.url === url)
+      .length === 0
+  ) {
+    storeHttpClient.availableStores.push({
+      name: opt.name,
+      url: url
+    });
+  }
+
   // Web socket URL.
   const wsUrl = `${url.replace(/^http/, 'ws')}/websocket`;
 
@@ -209,4 +221,22 @@ export default function storeHttpClient(url) {
       });
     }
   });
+}
+
+storeHttpClient.availableStores = [];
+
+/**
+ * Returns basic information about the store HTTP clients that have been created.
+ * @returns {Array} an array of store HTTP clients basic information
+ */
+export function getAvailableStores() {
+  return JSON.parse(JSON.stringify(storeHttpClient.availableStores));
+}
+
+/**
+ * Clears information about the store HTTP clients created.
+ * Should only be used for tests setup.
+ */
+export function clearAvailableStores() {
+  storeHttpClient.availableStores = [];
 }

--- a/packages/agent-js/test/create.js
+++ b/packages/agent-js/test/create.js
@@ -19,6 +19,11 @@ import memoryStore from '../src/memoryStore';
 import plugins from '../src/plugins';
 import Process from '../src/process';
 
+import fossilizerHttpClient, {
+  clearAvailableFossilizers
+} from '../src/fossilizerHttpClient';
+import storeHttpClient, { clearAvailableStores } from '../src/storeHttpClient';
+
 const actions = {
   init(a, b, c) {
     this.append({ a, b, c });
@@ -35,6 +40,8 @@ describe('Agent', () => {
 
   beforeEach(() => {
     agent = create({ agentUrl: 'http://localhost' });
+    clearAvailableFossilizers();
+    clearAvailableStores();
   });
 
   afterEach(() => {
@@ -50,6 +57,30 @@ describe('Agent', () => {
         Object.keys(infos.processes).length.should.be.exactly(2);
         Object.values(infos.processes)[0].should.be.an.Object();
         Object.values(infos.processes)[0].name.should.be.a.String();
+      });
+    });
+
+    it('returns a Promise resolving with information about the existing fossilizers', () => {
+      fossilizerHttpClient('http://fossilizer:6000', {
+        name: 'dummyfossilizer'
+      });
+
+      return agent.getInfo().then(infos => {
+        infos.fossilizers.should.be.an.Object();
+        infos.fossilizers.length.should.be.exactly(1);
+        infos.fossilizers[0].name.should.be.exactly('dummyfossilizer');
+        infos.fossilizers[0].url.should.be.exactly('http://fossilizer:6000');
+      });
+    });
+
+    it('returns a Promise resolving with information about the existing stores', () => {
+      storeHttpClient('http://store:5000', { name: 'tmstore' });
+
+      return agent.getInfo().then(infos => {
+        infos.stores.should.be.an.Object();
+        infos.stores.length.should.be.exactly(1);
+        infos.stores[0].name.should.be.exactly('tmstore');
+        infos.stores[0].url.should.be.exactly('http://store:5000');
       });
     });
   });


### PR DESCRIPTION
This is a first step to support dynamically adding new processes to a running agent.
The agent needs to expose the fossilizers and stores that it already knows. This way the new process that will be added can either directly use one of those or supply new { url, name } objects to use.
I'm really not sure this code is the best way to achieve this, don't hesitate to suggest something completely different or tell me if you don't like it :)