### PR TITLE
lint: install missing jslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-react": "^7.4.0",
+    "jslint": "^0.11.0",
     "lerna": "^2.2.0",
     "prettier": "^1.7.4"
   },


### PR DESCRIPTION
VS Code is complaining on a clean clone of the repo that jslint is missing.
Adding it fixes editor issues. 