### PR TITLE
build: use a single travis build for all packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@ sudo: false
 cache: yarn
 node_js:
   - 6
-env:
-  - PACKAGE=stratumn-agent-client
-  - PACKAGE=stratumn-agent
-  - PACKAGE=stratumn-agent-ui
-  - PACKAGE=mapexplorer-core
-  - PACKAGE=react-mapexplorer
-  - PACKAGE=angular-mapexplorer
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_script:
   - yarn global add codecov
   - lerna bootstrap
 script:
-  - npm run test:ci
-  - npm run lint:ci
+  - npm run test
+  - npm run lint
   - codecov

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
     "lint": "eslint packages/*/src packages/*/test",
-    "lint:ci": "lerna exec --scope $PACKAGE -- \\$LERNA_ROOT_PATH/node_modules/.bin/eslint \\$\\(pwd\\)/src \\$\\(pwd\\)/test",
+    "lint:ci": "eslint packages/*/src packages/*/test",
     "test": "lerna run test:ci",
-    "test:ci": "lerna run --scope $PACKAGE test:ci",
+    "test:ci": "lerna run test:ci",
     "update-license-headers": "./update-license-headers.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",
     "lint": "eslint packages/*/src packages/*/test",
-    "lint:ci": "eslint packages/*/src packages/*/test",
     "test": "lerna run test:ci",
-    "test:ci": "lerna run test:ci",
     "update-license-headers": "./update-license-headers.sh"
   }
 }


### PR DESCRIPTION
There are a few issues with using separate builds per package in the mono-repo:
- it looks like sometime the mapexplore-core build simply didn't start at all (Travis throttling us?)
- most of the time the builds were run sequentially, not in parallel, so the overall build time was much longer
- most of the build time is spent in the bootstrapping part anyway, so it's a bit of a waste to do that in each separate build

Most of these issues are probably because we're on the public (free) Travis.