### PR TITLE
agent-js: API to add a new process

### DIFF
--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -92,20 +92,13 @@ export default function httpServer(agent, opts = {}) {
           return res.status(400).json({ error: 'invalid script' });
         }
 
-        if (exported.name !== req.params.process) {
-          return res.status(400).json({
-            error:
-              "Process name from url doesn't match process name from the script"
-          });
-        }
-
         if (!exported.init || typeof exported.init !== 'function') {
           return res.status(400).json({
             error: 'missing init function'
           });
         }
 
-        agent.addProcess(exported.name, exported, memorystore(), null);
+        agent.addProcess(req.params.process, exported, memorystore(), null);
 
         return res.json(agent.getAllProcesses());
       } catch (err) {

--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -72,7 +72,7 @@ export default function httpServer(agent, opts = {}) {
    * setup to restrict access to this API.
    */
   if (opts.enableProcessUpload) {
-    app.post('/:process/add', (req, res, next) => {
+    app.post('/:process/upload', (req, res, next) => {
       try {
         if (!req.body.script) {
           return res.status(400).json({ error: 'missing script' });

--- a/packages/agent-js/test/httpServer.js
+++ b/packages/agent-js/test/httpServer.js
@@ -105,10 +105,31 @@ describe('HttpServer()', () => {
         '};'
     ).toString('base64');
 
-    it('adds a new process and returns the updated list of processes', () => {
+    let serverWithProcessUpload;
+
+    beforeEach(() => {
+      serverWithProcessUpload = agent.httpServer({ enableProcessUpload: true });
+    });
+
+    it('is disabled by default', () => {
       const hotProcess = { script: encodedScript };
 
       const req = supertest(server)
+        .post('/hot/add')
+        .send(hotProcess);
+
+      return testFn(req, (err, res) => {
+        if (err) {
+          throw err;
+        }
+        res.status.should.be.exactly(404);
+      });
+    });
+
+    it('adds a new process and returns the updated list of processes', () => {
+      const hotProcess = { script: encodedScript };
+
+      const req = supertest(serverWithProcessUpload)
         .post('/hot/add')
         .send(hotProcess);
 
@@ -125,7 +146,7 @@ describe('HttpServer()', () => {
 
     it('rejects process with name mismatch', () => {
       const hotProcess = { script: encodedScript };
-      const req = supertest(server)
+      const req = supertest(serverWithProcessUpload)
         .post('/not-the-right-name/add')
         .send(hotProcess);
 
@@ -142,7 +163,7 @@ describe('HttpServer()', () => {
 
     it('rejects process with missing script', () => {
       const hotProcess = { script: '' };
-      const req = supertest(server)
+      const req = supertest(serverWithProcessUpload)
         .post('/hot/add')
         .send(hotProcess);
 
@@ -161,7 +182,7 @@ describe('HttpServer()', () => {
       ).toString('base64');
 
       const hotProcess = { script: missingFunctions };
-      const req = supertest(server)
+      const req = supertest(serverWithProcessUpload)
         .post('/hot/add')
         .send(hotProcess);
 
@@ -176,7 +197,7 @@ describe('HttpServer()', () => {
 
     it('rejects process with invalid script', () => {
       const hotProcess = { script: 'this is definitely not a valid script' };
-      const req = supertest(server)
+      const req = supertest(serverWithProcessUpload)
         .post('/hot/add')
         .send(hotProcess);
 

--- a/packages/agent-js/test/httpServer.js
+++ b/packages/agent-js/test/httpServer.js
@@ -92,7 +92,6 @@ describe('HttpServer()', () => {
   describe('POST "/<process>/add"', () => {
     const encodedScript = Buffer.from(
       'module.exports = { ' +
-        "name:'hot', " +
         'init: function(title) {' +
         'if (!title) {' +
         "return this.reject('a title is required');" +
@@ -141,23 +140,6 @@ describe('HttpServer()', () => {
         const processes = res.body;
         processes.length.should.be.exactly(2);
         processes[1].name.should.be.exactly('hot');
-      });
-    });
-
-    it('rejects process with name mismatch', () => {
-      const hotProcess = { script: encodedScript };
-      const req = supertest(serverWithProcessUpload)
-        .post('/not-the-right-name/add')
-        .send(hotProcess);
-
-      return testFn(req, (err, res) => {
-        if (err) {
-          throw err;
-        }
-        res.status.should.be.exactly(400);
-        res.body.error.should.be.exactly(
-          "Process name from url doesn't match process name from the script"
-        );
       });
     });
 

--- a/packages/agent-js/test/httpServer.js
+++ b/packages/agent-js/test/httpServer.js
@@ -89,7 +89,7 @@ describe('HttpServer()', () => {
     });
   });
 
-  describe('POST "/<process>/add"', () => {
+  describe('POST "/<process>/upload"', () => {
     const validEncodedScript = Buffer.from(
       'module.exports = { ' +
         'init: function(title) {' +
@@ -118,7 +118,7 @@ describe('HttpServer()', () => {
     ) => {
       const newProcess = { script: encodedScript };
       const req = supertest(testServer)
-        .post(`/${processName}/add`)
+        .post(`/${processName}/upload`)
         .send(newProcess);
 
       return testFn(req, (err, res) => {


### PR DESCRIPTION
Adding a new API on the agent to allow dynamic upload of a new process (by script injection).
We most likely only want to allow this for test networks as an opt-in (it's way too dangerous otherwise) so I think I'll disable this API by default and allow enabling it (instead of having it enabled by default like what we have in this PR). What do you think?

Note: this is still lacking configuration of the store and fossilizer (hence the memorystore used and null fossilizer). This will come in another PR to keep this one small (since it raises a few issues, I'd like to focus on those before implementing store/fossilizer configuration which can also raise other issues).
