### PR TITLE
agent-js: process upload API accepts store and fossilizer configuration

### DIFF
--- a/packages/agent-js/src/fossilizerHttpClient.js
+++ b/packages/agent-js/src/fossilizerHttpClient.js
@@ -26,11 +26,8 @@ import handleResponse from './handleResponse';
  */
 export default function fossilizerHttpClient(url, opts = {}) {
   // If we already have an existing fossilizer for that url, re-use it
-  const matchingFossilizerClient = fossilizerHttpClient.availableFossilizers.find(
-    foss => foss.url === url
-  );
-  if (matchingFossilizerClient) {
-    return matchingFossilizerClient.client;
+  if (fossilizerHttpClient.availableFossilizers[url]) {
+    return fossilizerHttpClient.availableFossilizers[url];
   }
 
   const fossilizerClient = {
@@ -78,22 +75,21 @@ export default function fossilizerHttpClient(url, opts = {}) {
     }
   };
 
-  fossilizerHttpClient.availableFossilizers.push({
-    url: url,
-    client: fossilizerClient
-  });
+  fossilizerHttpClient.availableFossilizers[url] = fossilizerClient;
 
   return fossilizerClient;
 }
 
-fossilizerHttpClient.availableFossilizers = [];
+fossilizerHttpClient.availableFossilizers = {};
 
 /**
  * Returns basic information about the fossilizer HTTP clients that have been created.
- * @returns {Array} an array of fossilizer HTTP clients basic information
+ * @returns {Array} an array of fossilizer HTTP clients basic information (currently only url).
  */
 export function getAvailableFossilizers() {
-  return fossilizerHttpClient.availableFossilizers.map(f => ({ url: f.url }));
+  return Object.keys(fossilizerHttpClient.availableFossilizers).map(url => ({
+    url
+  }));
 }
 
 /**
@@ -101,5 +97,5 @@ export function getAvailableFossilizers() {
  * Should only be used for tests setup.
  */
 export function clearAvailableFossilizers() {
-  fossilizerHttpClient.availableFossilizers = [];
+  fossilizerHttpClient.availableFossilizers = {};
 }

--- a/packages/agent-js/src/fossilizerHttpClient.js
+++ b/packages/agent-js/src/fossilizerHttpClient.js
@@ -22,7 +22,6 @@ import handleResponse from './handleResponse';
  * @param {string} url - the base URL of the fossilizer
  * @param {object} [opts] - options
  * @param {function} [opts.callbackUrl] - builds a URL that will be called with the evidence
- * @param {string} [opts.name] - the name of the fossilizer
  * @returns {Client} a fossilizer HTTP client
  */
 export default function fossilizerHttpClient(url, opts = {}) {
@@ -31,10 +30,6 @@ export default function fossilizerHttpClient(url, opts = {}) {
     foss => foss.url === url
   );
   if (matchingFossilizerClient) {
-    if (!matchingFossilizerClient.name && opts.name) {
-      matchingFossilizerClient.name = opts.name;
-    }
-
     return matchingFossilizerClient.client;
   }
 
@@ -84,7 +79,6 @@ export default function fossilizerHttpClient(url, opts = {}) {
   };
 
   fossilizerHttpClient.availableFossilizers.push({
-    name: opts.name,
     url: url,
     client: fossilizerClient
   });
@@ -99,10 +93,7 @@ fossilizerHttpClient.availableFossilizers = [];
  * @returns {Array} an array of fossilizer HTTP clients basic information
  */
 export function getAvailableFossilizers() {
-  return fossilizerHttpClient.availableFossilizers.map(f => ({
-    name: f.name,
-    url: f.url
-  }));
+  return fossilizerHttpClient.availableFossilizers.map(f => ({ url: f.url }));
 }
 
 /**

--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -90,21 +90,21 @@ export default function httpServer(agent, opts = {}) {
         throw err;
       }
 
-      let process;
+      let processActions;
       try {
-        process = parseProcessActions(req.body.actions);
+        processActions = parseProcessActions(req.body.actions);
       } catch (e) {
         console.error(`upload process: ${e}`);
         err.message = 'invalid actions';
         throw err;
       }
 
-      if (!process.init || typeof process.init !== 'function') {
+      if (!processActions.init || typeof processActions.init !== 'function') {
         err.message = 'missing init function';
         throw err;
       }
 
-      return process;
+      return processActions;
     };
 
     const getStore = store => storeHttpClient(store.url);
@@ -128,11 +128,11 @@ export default function httpServer(agent, opts = {}) {
     };
 
     app.post('/:process/upload', (req, res) => {
-      const process = validateProcessUpload(req);
+      const processActions = validateProcessUpload(req);
       const store = getStore(req.body.store);
       const fossilizers = getFossilizers(req.body.fossilizers);
 
-      agent.addProcess(req.params.process, process, store, fossilizers);
+      agent.addProcess(req.params.process, processActions, store, fossilizers);
 
       return res.json(agent.getAllProcesses());
     });

--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -107,12 +107,12 @@ export default function httpServer(agent, opts = {}) {
       return process;
     };
 
-    const getOrCreateStore = store =>
+    const getStore = store =>
       storeHttpClient(store.url, {
         name: store.name
       });
 
-    const getOrCreateFossilizers = reqFossilizers => {
+    const getFossilizers = reqFossilizers => {
       let fossilizers = [];
       if (reqFossilizers) {
         fossilizers = reqFossilizers
@@ -123,9 +123,7 @@ export default function httpServer(agent, opts = {}) {
               });
             }
 
-            console.error(
-              'Fossilizer is missing url or evidenceCallbackUrl. Skipping...'
-            );
+            console.error('Fossilizer is missing url. Skipping...');
             return null;
           })
           .filter(f => f !== null);
@@ -136,8 +134,8 @@ export default function httpServer(agent, opts = {}) {
 
     app.post('/:process/upload', (req, res) => {
       const process = validateProcessUpload(req);
-      const store = getOrCreateStore(req.body.store);
-      const fossilizers = getOrCreateFossilizers(req.body.fossilizers);
+      const store = getStore(req.body.store);
+      const fossilizers = getFossilizers(req.body.fossilizers);
 
       agent.addProcess(req.params.process, process, store, fossilizers);
 

--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -86,7 +86,7 @@ export default function httpServer(agent, opts = {}) {
       }
 
       if (!req.body.store || !req.body.store.url) {
-        err.message = 'missing store configuration';
+        err.message = 'missing store url';
         throw err;
       }
 
@@ -107,10 +107,7 @@ export default function httpServer(agent, opts = {}) {
       return process;
     };
 
-    const getStore = store =>
-      storeHttpClient(store.url, {
-        name: store.name
-      });
+    const getStore = store => storeHttpClient(store.url);
 
     const getFossilizers = reqFossilizers => {
       let fossilizers = [];
@@ -118,9 +115,7 @@ export default function httpServer(agent, opts = {}) {
         fossilizers = reqFossilizers
           .map(f => {
             if (f.url) {
-              return fossilizerHttpClient(f.url, {
-                name: f.name
-              });
+              return fossilizerHttpClient(f.url);
             }
 
             console.error('Fossilizer is missing url. Skipping...');

--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -65,23 +65,23 @@ export default function httpServer(agent, opts = {}) {
    * setup to restrict access to this API.
    */
   if (opts.enableProcessUpload) {
-    const parseProcessScript = script => {
-      const processModule = new module.constructor();
+    const parseProcessActions = actions => {
+      const processActionsModule = new module.constructor();
       /* eslint-disable no-underscore-dangle */
-      processModule._compile(
-        Buffer.from(script, 'base64').toString(),
+      processActionsModule._compile(
+        Buffer.from(actions, 'base64').toString(),
         '' // this parameter is actually required (undefined isn't accepted)
       );
       /* eslint-enable no-underscore-dangle */
-      return processModule.exports;
+      return processActionsModule.exports;
     };
 
     const validateProcessUpload = req => {
       const err = new Error();
       err.status = 400;
 
-      if (!req.body.script) {
-        err.message = 'missing script';
+      if (!req.body.actions) {
+        err.message = 'missing actions';
         throw err;
       }
 
@@ -92,10 +92,10 @@ export default function httpServer(agent, opts = {}) {
 
       let process;
       try {
-        process = parseProcessScript(req.body.script);
+        process = parseProcessActions(req.body.actions);
       } catch (e) {
         console.error(`upload process: ${e}`);
-        err.message = 'invalid script';
+        err.message = 'invalid actions';
         throw err;
       }
 

--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -107,14 +107,18 @@ export default function httpServer(agent, opts = {}) {
       return process;
     };
 
-    const createFossilizers = reqFossilizers => {
+    const getOrCreateStore = store =>
+      storeHttpClient(store.url, {
+        name: store.name
+      });
+
+    const getOrCreateFossilizers = reqFossilizers => {
       let fossilizers = [];
       if (reqFossilizers) {
         fossilizers = reqFossilizers
           .map(f => {
-            if (f.url && f.evidenceCallbackUrl) {
+            if (f.url) {
               return fossilizerHttpClient(f.url, {
-                callbackUrl: f.evidenceCallbackUrl,
                 name: f.name
               });
             }
@@ -132,12 +136,8 @@ export default function httpServer(agent, opts = {}) {
 
     app.post('/:process/upload', (req, res) => {
       const process = validateProcessUpload(req);
-
-      const store = storeHttpClient(req.body.store.url, {
-        name: req.body.store.name
-      });
-
-      const fossilizers = createFossilizers(req.body.fossilizers);
+      const store = getOrCreateStore(req.body.store);
+      const fossilizers = getOrCreateFossilizers(req.body.fossilizers);
 
       agent.addProcess(req.params.process, process, store, fossilizers);
 

--- a/packages/agent-js/src/storeHttpClient.js
+++ b/packages/agent-js/src/storeHttpClient.js
@@ -31,20 +31,14 @@ import handleResponse from './handleResponse';
  *   - 'didSave': a segment was saved
  *
  * @param {string} url - the base URL of the store
- * @param {object} [opt] - options
- * @param {string} [opt.name] - the name of the store
  * @returns {Client} a store HTTP client
  */
-export default function storeHttpClient(url, opt = {}) {
+export default function storeHttpClient(url) {
   // If we already have an existing store for that url, re-use it
   const matchingStoreClient = storeHttpClient.availableStores.find(
     store => store.url === url
   );
   if (matchingStoreClient) {
-    if (!matchingStoreClient.name && opt.name) {
-      matchingStoreClient.name = opt.name;
-    }
-
     return matchingStoreClient.client;
   }
 
@@ -196,7 +190,6 @@ export default function storeHttpClient(url, opt = {}) {
   });
 
   storeHttpClient.availableStores.push({
-    name: opt.name,
     url: url,
     client: storeClient
   });
@@ -211,10 +204,7 @@ storeHttpClient.availableStores = [];
  * @returns {Array} an array of store HTTP clients basic information
  */
 export function getAvailableStores() {
-  return storeHttpClient.availableStores.map(s => ({
-    name: s.name,
-    url: s.url
-  }));
+  return storeHttpClient.availableStores.map(s => ({ url: s.url }));
 }
 
 /**

--- a/packages/agent-js/src/storeHttpClient.js
+++ b/packages/agent-js/src/storeHttpClient.js
@@ -35,11 +35,8 @@ import handleResponse from './handleResponse';
  */
 export default function storeHttpClient(url) {
   // If we already have an existing store for that url, re-use it
-  const matchingStoreClient = storeHttpClient.availableStores.find(
-    store => store.url === url
-  );
-  if (matchingStoreClient) {
-    return matchingStoreClient.client;
+  if (storeHttpClient.availableStores[url]) {
+    return storeHttpClient.availableStores[url];
   }
 
   // Web socket URL.
@@ -189,22 +186,19 @@ export default function storeHttpClient(url) {
     }
   });
 
-  storeHttpClient.availableStores.push({
-    url: url,
-    client: storeClient
-  });
+  storeHttpClient.availableStores[url] = storeClient;
 
   return storeClient;
 }
 
-storeHttpClient.availableStores = [];
+storeHttpClient.availableStores = {};
 
 /**
  * Returns basic information about the store HTTP clients that have been created.
- * @returns {Array} an array of store HTTP clients basic information
+ * @returns {Array} an array of store HTTP clients basic information (currently only url).
  */
 export function getAvailableStores() {
-  return storeHttpClient.availableStores.map(s => ({ url: s.url }));
+  return Object.keys(storeHttpClient.availableStores).map(url => ({ url }));
 }
 
 /**
@@ -212,5 +206,5 @@ export function getAvailableStores() {
  * Should only be used for tests setup.
  */
 export function clearAvailableStores() {
-  storeHttpClient.availableStores = [];
+  storeHttpClient.availableStores = {};
 }

--- a/packages/agent-js/test/create.js
+++ b/packages/agent-js/test/create.js
@@ -63,25 +63,21 @@ describe('Agent', () => {
     });
 
     it('returns a Promise resolving with information about the existing fossilizers', () => {
-      fossilizerHttpClient('http://fossilizer:6000', {
-        name: 'dummyfossilizer'
-      });
+      fossilizerHttpClient('http://fossilizer:6000');
 
       return agent.getInfo().then(infos => {
         infos.fossilizers.should.be.an.Object();
         infos.fossilizers.length.should.be.exactly(1);
-        infos.fossilizers[0].name.should.be.exactly('dummyfossilizer');
         infos.fossilizers[0].url.should.be.exactly('http://fossilizer:6000');
       });
     });
 
     it('returns a Promise resolving with information about the existing stores', () => {
-      storeHttpClient('http://store:5000', { name: 'tmstore' });
+      storeHttpClient('http://store:5000');
 
       return agent.getInfo().then(infos => {
         infos.stores.should.be.an.Object();
         infos.stores.length.should.be.exactly(1);
-        infos.stores[0].name.should.be.exactly('tmstore');
         infos.stores[0].url.should.be.exactly('http://store:5000');
       });
     });

--- a/packages/agent-js/test/httpServer.js
+++ b/packages/agent-js/test/httpServer.js
@@ -171,13 +171,11 @@ describe('HttpServer()', () => {
         [
           {
             name: 'btc',
-            url: 'http://fossilizer:6000',
-            evidenceCallbackUrl: 'http://agent:3000'
+            url: 'http://fossilizer:6000'
           },
           {
             name: 'bch',
-            url: 'http://fossilizer:6001',
-            evidenceCallbackUrl: 'http://agent:3000'
+            url: 'http://fossilizer:6001'
           }
         ]
       );

--- a/packages/agent-js/test/httpServer.js
+++ b/packages/agent-js/test/httpServer.js
@@ -97,7 +97,7 @@ describe('HttpServer()', () => {
   });
 
   describe('POST "/<process>/upload"', () => {
-    const validEncodedScript = Buffer.from(
+    const validEncodedActions = Buffer.from(
       'module.exports = { ' +
         'init: function(title) {' +
         'if (!title) {' +
@@ -118,11 +118,11 @@ describe('HttpServer()', () => {
     });
 
     const createRequest = (
-      encodedScript = validEncodedScript,
+      encodedActions = validEncodedActions,
       store = { url: 'http://localhost:5000' },
       fossilizers = []
     ) => ({
-      script: encodedScript,
+      actions: encodedActions,
       store: store,
       fossilizers: fossilizers
     });
@@ -166,7 +166,7 @@ describe('HttpServer()', () => {
 
     it('supports store and fossilizers', () => {
       const request = createRequest(
-        validEncodedScript,
+        validEncodedActions,
         { url: 'http://store:5000' },
         [
           {
@@ -192,13 +192,13 @@ describe('HttpServer()', () => {
       );
     });
 
-    it('rejects process with missing script', () =>
+    it('rejects process with missing actions', () =>
       uploadProcessAndValidate(
         serverWithProcessUpload,
         createRequest(''),
         res => {
           res.status.should.be.exactly(400);
-          res.body.error.should.be.exactly('missing script');
+          res.body.error.should.be.exactly('missing actions');
         }
       ));
 
@@ -217,20 +217,20 @@ describe('HttpServer()', () => {
       );
     });
 
-    it('rejects process with invalid script', () => {
-      const invalidScript = 'this is definitely not a valid script';
+    it('rejects process with invalid actions script', () => {
+      const invalidActions = 'this is definitely not a valid script';
       return uploadProcessAndValidate(
         serverWithProcessUpload,
-        createRequest(invalidScript),
+        createRequest(invalidActions),
         res => {
           res.status.should.be.exactly(400);
-          res.body.error.should.be.exactly('invalid script');
+          res.body.error.should.be.exactly('invalid actions');
         }
       );
     });
 
     it('rejects process with missing store configuration', () => {
-      const request = createRequest(validEncodedScript, { url: '' });
+      const request = createRequest(validEncodedActions, { url: '' });
       return uploadProcessAndValidate(serverWithProcessUpload, request, res => {
         res.status.should.be.exactly(400);
         res.body.error.should.be.exactly('missing store url');

--- a/packages/agent-js/test/httpServer.js
+++ b/packages/agent-js/test/httpServer.js
@@ -196,35 +196,6 @@ describe('HttpServer()', () => {
       );
     });
 
-    it('skips invalid fossilizers', () => {
-      const request = createRequest(
-        validEncodedScript,
-        { name: 'store', url: 'http://store:5000' },
-        [
-          {
-            name: 'btc',
-            url: 'http://fossilizer:6000'
-          },
-          {
-            name: 'bch',
-            url: 'http://fossilizer:6001',
-            evidenceCallbackUrl: 'http://agent:3000'
-          }
-        ]
-      );
-
-      return uploadProcessAndValidate(
-        serverWithProcessUpload,
-        request,
-        res => {
-          res.status.should.be.exactly(200);
-          const newProcess = res.body.find(p => p.name === 'withStore');
-          newProcess.fossilizerClients.length.should.be.exactly(1);
-        },
-        'withStore'
-      );
-    });
-
     it('rejects process with missing script', () =>
       uploadProcessAndValidate(
         serverWithProcessUpload,

--- a/packages/agent-js/test/httpServer.js
+++ b/packages/agent-js/test/httpServer.js
@@ -119,7 +119,7 @@ describe('HttpServer()', () => {
 
     const createRequest = (
       encodedScript = validEncodedScript,
-      store = { name: 'test', url: 'http://localhost:5000' },
+      store = { url: 'http://localhost:5000' },
       fossilizers = []
     ) => ({
       script: encodedScript,
@@ -167,14 +167,12 @@ describe('HttpServer()', () => {
     it('supports store and fossilizers', () => {
       const request = createRequest(
         validEncodedScript,
-        { name: 'store', url: 'http://store:5000' },
+        { url: 'http://store:5000' },
         [
           {
-            name: 'btc',
             url: 'http://fossilizer:6000'
           },
           {
-            name: 'bch',
             url: 'http://fossilizer:6001'
           }
         ]
@@ -232,12 +230,10 @@ describe('HttpServer()', () => {
     });
 
     it('rejects process with missing store configuration', () => {
-      const request = createRequest(validEncodedScript, {
-        name: 'missing-url'
-      });
+      const request = createRequest(validEncodedScript, { url: '' });
       return uploadProcessAndValidate(serverWithProcessUpload, request, res => {
         res.status.should.be.exactly(400);
-        res.body.error.should.be.exactly('missing store configuration');
+        res.body.error.should.be.exactly('missing store url');
       });
     });
   });

--- a/packages/agent-js/test/storeFossilizerClient.js
+++ b/packages/agent-js/test/storeFossilizerClient.js
@@ -51,41 +51,24 @@ describe('FossilizerHttpClient', () => {
     });
 
     it('tracks fossilizer clients that are created', () => {
-      fossilizerHttpClient('http://fossilizer1:6000', { name: '1' });
-      fossilizerHttpClient('http://fossilizer2:6001', { name: '2' });
+      fossilizerHttpClient('http://fossilizer1:6000');
+      fossilizerHttpClient('http://fossilizer2:6001');
 
       getAvailableFossilizers().length.should.be.exactly(2);
-
-      getAvailableFossilizers()[0].name.should.be.exactly('1');
       getAvailableFossilizers()[0].url.should.be.exactly(
         'http://fossilizer1:6000'
       );
-
-      getAvailableFossilizers()[1].name.should.be.exactly('2');
       getAvailableFossilizers()[1].url.should.be.exactly(
         'http://fossilizer2:6001'
       );
-    });
-
-    it('does not store duplicate fossilizers', () => {
-      fossilizerHttpClient('http://fossilizer:6000', { name: '1' });
-      fossilizerHttpClient('http://fossilizer:6000', { name: '2' });
-
-      getAvailableFossilizers().length.should.be.exactly(1);
     });
 
     it('does not create duplicate fossilizers for the same url', () => {
       const fossilizerClient1 = fossilizerHttpClient('http://fossilizer:6000');
       const fossilizerClient2 = fossilizerHttpClient('http://fossilizer:6000');
 
+      getAvailableFossilizers().length.should.be.exactly(1);
       fossilizerClient1.should.equal(fossilizerClient2);
-    });
-
-    it('accepts missing names for backwards compatibility', () => {
-      fossilizerHttpClient('http://fossilizer:6000', { name: '1' });
-      fossilizerHttpClient('http://fossilizer:6001');
-
-      getAvailableFossilizers().length.should.be.exactly(2);
     });
   });
 

--- a/packages/agent-js/test/storeFossilizerClient.js
+++ b/packages/agent-js/test/storeFossilizerClient.js
@@ -74,6 +74,13 @@ describe('FossilizerHttpClient', () => {
       getAvailableFossilizers().length.should.be.exactly(1);
     });
 
+    it('does not create duplicate fossilizers for the same url', () => {
+      const fossilizerClient1 = fossilizerHttpClient('http://fossilizer:6000');
+      const fossilizerClient2 = fossilizerHttpClient('http://fossilizer:6000');
+
+      fossilizerClient1.should.equal(fossilizerClient2);
+    });
+
     it('accepts missing names for backwards compatibility', () => {
       fossilizerHttpClient('http://fossilizer:6000', { name: '1' });
       fossilizerHttpClient('http://fossilizer:6001');

--- a/packages/agent-js/test/storeHttpClient.js
+++ b/packages/agent-js/test/storeHttpClient.js
@@ -51,11 +51,26 @@ describe('StoreHttpClient', () => {
       getAvailableStores().length.should.be.exactly(1);
     });
 
+    it('does not create duplicate stores for the same url', () => {
+      const storeClient1 = storeHttpClient('http://store:5000');
+      const storeClient2 = storeHttpClient('http://store:5000');
+
+      storeClient1.should.equal(storeClient2);
+    });
+
     it('accepts missing names for backwards compatibility', () => {
       storeHttpClient('http://store:5000', { name: '1' });
       storeHttpClient('http://store:5001');
 
       getAvailableStores().length.should.be.exactly(2);
+    });
+
+    it('enriches existing store with a name if provided', () => {
+      storeHttpClient('http://store:5000');
+      storeHttpClient('http://store:5000', { name: 'store' });
+
+      getAvailableStores().length.should.be.exactly(1);
+      getAvailableStores()[0].name.should.be.exactly('store');
     });
   });
 

--- a/packages/agent-js/test/storeHttpClient.js
+++ b/packages/agent-js/test/storeHttpClient.js
@@ -32,45 +32,20 @@ describe('StoreHttpClient', () => {
     });
 
     it('tracks store clients that are created', () => {
-      storeHttpClient('http://store1:5000', { name: '1' });
-      storeHttpClient('http://store2:5001', { name: '2' });
+      storeHttpClient('http://store1:5000');
+      storeHttpClient('http://store2:5001');
 
       getAvailableStores().length.should.be.exactly(2);
-
-      getAvailableStores()[0].name.should.be.exactly('1');
       getAvailableStores()[0].url.should.be.exactly('http://store1:5000');
-
-      getAvailableStores()[1].name.should.be.exactly('2');
       getAvailableStores()[1].url.should.be.exactly('http://store2:5001');
-    });
-
-    it('does not store duplicate store clients', () => {
-      storeHttpClient('http://store:5000', { name: '1' });
-      storeHttpClient('http://store:5000', { name: '2' });
-
-      getAvailableStores().length.should.be.exactly(1);
     });
 
     it('does not create duplicate stores for the same url', () => {
       const storeClient1 = storeHttpClient('http://store:5000');
       const storeClient2 = storeHttpClient('http://store:5000');
 
-      storeClient1.should.equal(storeClient2);
-    });
-
-    it('accepts missing names for backwards compatibility', () => {
-      storeHttpClient('http://store:5000', { name: '1' });
-      storeHttpClient('http://store:5001');
-
-      getAvailableStores().length.should.be.exactly(2);
-    });
-
-    it('enriches existing store with a name if provided', () => {
-      storeHttpClient('http://store:5000');
-      storeHttpClient('http://store:5000', { name: 'store' });
-
       getAvailableStores().length.should.be.exactly(1);
-      getAvailableStores()[0].name.should.be.exactly('store');
+      storeClient1.should.equal(storeClient2);
     });
   });
 


### PR DESCRIPTION
Adding store and fossilizer configuration options to the process upload API.
Refactored the process upload API as well (extracted several smaller functions).
I have one open question about the evidence callback url: I'm currently forcing the caller to specify a callback url for each fossilizer. This is maybe a bit drastic, if none is specified I could use agent.agentUrl or something like it as a default value, what do you think?
Overall I found that the evidence callback url could be configured via a few different variables so I'm a bit unclear about this, maybe it needs a bit of refactoring?