### PR TITLE
agent-ui: left drawer correctly handles agents with no processes

### DIFF
--- a/packages/agent-ui/src/containers/leftNavigation.js
+++ b/packages/agent-ui/src/containers/leftNavigation.js
@@ -40,15 +40,14 @@ LeftNavigation.propTypes = {
   ).isRequired
 };
 
-function mapStateToProps(state, ownProps) {
-  console.log('LeftNavigation state', state);
-  console.log('LeftNavigation ownProps', ownProps);
-
+export function mapStateToProps(state) {
   let agents = [];
   if (state.agents) {
     agents = Object.keys(state.agents).map(agentName => ({
       name: agentName,
-      processes: Object.keys(state.agents[agentName].processes)
+      processes: state.agents[agentName].processes
+        ? Object.keys(state.agents[agentName].processes)
+        : []
     }));
   }
 

--- a/packages/agent-ui/src/containers/leftNavigation.test.js
+++ b/packages/agent-ui/src/containers/leftNavigation.test.js
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 
-import { LeftNavigation } from './leftNavigation';
+import { LeftNavigation, mapStateToProps } from './leftNavigation';
 
 describe('<LeftNavigation />', () => {
   it('displays the list of agents and processes', () => {
@@ -27,5 +27,24 @@ describe('<LeftNavigation />', () => {
     ['a1', 'a2', 'a3', 'p1', 'p2', 'p3'].map(val =>
       expect(linksTexts.includes(val)).to.equal(true)
     );
+  });
+
+  it('correctly maps state to props', () => {
+    const state = {
+      agents: {
+        a1: {
+          processes: {
+            p1: {}
+          }
+        },
+        a2: {}
+      }
+    };
+
+    const props = mapStateToProps(state);
+    expect(props.agents).to.deep.equal([
+      { name: 'a1', processes: ['p1'] },
+      { name: 'a2', processes: [] }
+    ]);
   });
 });


### PR DESCRIPTION
The mapStateToProps function wasn't unit tested and didn't properly handle missing processes (either because agent loading failed or  because the agent didn't contain any processes)