### PR TITLE
agent-js: process upload: allow plugin configuration

### DIFF
--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -127,12 +127,26 @@ export default function httpServer(agent, opts = {}) {
       return fossilizers;
     };
 
+    const getPlugins = reqPlugins => {
+      const activePlugins = agent.getActivePlugins();
+      if (!activePlugins || !reqPlugins) {
+        return [];
+      }
+
+      return reqPlugins
+        .filter(({ id }) => activePlugins[id])
+        .map(({ id }) => activePlugins[id]);
+    };
+
     app.post('/:process/upload', (req, res) => {
       const processActions = validateProcessUpload(req);
       const store = getStore(req.body.store);
       const fossilizers = getFossilizers(req.body.fossilizers);
+      const plugins = getPlugins(req.body.plugins);
 
-      agent.addProcess(req.params.process, processActions, store, fossilizers);
+      agent.addProcess(req.params.process, processActions, store, fossilizers, {
+        plugins: plugins
+      });
 
       return res.json(agent.getAllProcesses());
     });

--- a/packages/agent-js/test/create.js
+++ b/packages/agent-js/test/create.js
@@ -81,6 +81,40 @@ describe('Agent', () => {
         infos.stores[0].url.should.be.exactly('http://store:5000');
       });
     });
+
+    it('returns the list of indexed active plugins', () => {
+      agent.addProcess('plugins1', actions, memoryStore(), null, {
+        plugins: [plugins.stateHash, plugins.agentUrl('http://localhost:3000')]
+      });
+      agent.addProcess('plugins2', actions, memoryStore(), null, {
+        plugins: [plugins.localTime]
+      });
+
+      return agent.getInfo().then(infos => {
+        infos.plugins.should.be.an.Array();
+        infos.plugins.length.should.be.exactly(3);
+        infos.plugins[2].should.eql({
+          id: '3',
+          name: plugins.localTime.name,
+          description: plugins.localTime.description
+        });
+      });
+    });
+
+    it('does not store duplicate plugin instances', () => {
+      // Since plugins.stateHash doesn't take arguments, both processes will share the same first plugin
+      agent.addProcess('plugins1', actions, memoryStore(), null, {
+        plugins: [plugins.stateHash, plugins.agentUrl('http://localhost:3000')]
+      });
+      agent.addProcess('plugins2', actions, memoryStore(), null, {
+        plugins: [plugins.stateHash, plugins.agentUrl('http://localhost:3001')]
+      });
+
+      return agent.getInfo().then(infos => {
+        infos.plugins.should.be.an.Array();
+        infos.plugins.length.should.be.exactly(3);
+      });
+    });
   });
 
   describe('#addProcess', () => {


### PR DESCRIPTION
When uploading a new process to a running agent, we want to be able to re-use existing plugins for this new process.
Agent now stores and exposes the plugins it has already instantiated, and uploaded processes specify the ids of the plugin instances they want to use.