### PR TITLE
agent-ui: refetch maps and segments when props change

### DIFF
--- a/packages/agent-ui/src/containers/processMapsPage.js
+++ b/packages/agent-ui/src/containers/processMapsPage.js
@@ -12,6 +12,14 @@ export class ProcessMapsPage extends Component {
     fetchMapIds(agent, process);
   }
 
+  componentWillReceiveProps(nextProps) {
+    const { agent, process, fetchMapIds } = nextProps;
+    const { agent: thisAgent, process: thisProcess } = this.props;
+    if (agent !== thisAgent || process !== thisProcess) {
+      fetchMapIds(agent, process);
+    }
+  }
+
   render() {
     const { maps: { status, mapIds, error } } = this.props;
     switch (status) {

--- a/packages/agent-ui/src/containers/processMapsPage.test.js
+++ b/packages/agent-ui/src/containers/processMapsPage.test.js
@@ -75,4 +75,34 @@ describe('<ProcessMapsPage />', () => {
     expect(div.contains('foo')).to.be.true;
     expect(div.contains('bar')).to.be.true;
   });
+
+  it('re renders when agent or process props changes', () => {
+    const props = {
+      fetchMapIds: sinon.spy(),
+      agent: 'foo',
+      process: 'bar',
+      maps: { status: statusTypes.LOADED, mapIds: [] }
+    };
+    const processMapsPage = mount(<ProcessMapsPage {...props} />);
+    processMapsPage.setProps({ ...props, agent: 'crazy' });
+    expect(props.fetchMapIds.callCount).to.equal(2);
+    expect(props.fetchMapIds.getCall(1).args[0]).to.equal('crazy');
+    expect(props.fetchMapIds.getCall(1).args[1]).to.equal('bar');
+    processMapsPage.setProps({ ...props, process: 'crazy' });
+    expect(props.fetchMapIds.callCount).to.equal(3);
+    expect(props.fetchMapIds.getCall(2).args[0]).to.equal('foo');
+    expect(props.fetchMapIds.getCall(2).args[1]).to.equal('crazy');
+  });
+
+  it('does not re renders when other props changes', () => {
+    const props = {
+      fetchMapIds: sinon.spy(),
+      agent: 'foo',
+      process: 'bar',
+      maps: { status: statusTypes.LOADED, mapIds: [] }
+    };
+    const processMapsPage = mount(<ProcessMapsPage {...props} />);
+    processMapsPage.setProps({ ...props, something: 'else' });
+    expect(props.fetchMapIds.callCount).to.equal(1);
+  });
 });

--- a/packages/agent-ui/src/containers/processSegmentsPage.js
+++ b/packages/agent-ui/src/containers/processSegmentsPage.js
@@ -12,6 +12,14 @@ export class ProcessSegmentsPage extends Component {
     fetchSegments(agent, process);
   }
 
+  componentWillReceiveProps(nextProps) {
+    const { agent, process, fetchSegments } = nextProps;
+    const { agent: thisAgent, process: thisProcess } = this.props;
+    if (agent !== thisAgent || process !== thisProcess) {
+      fetchSegments(agent, process);
+    }
+  }
+
   render() {
     const { segments: { status, details, error } } = this.props;
     switch (status) {

--- a/packages/agent-ui/src/containers/processSegmentsPage.test.js
+++ b/packages/agent-ui/src/containers/processSegmentsPage.test.js
@@ -67,4 +67,34 @@ describe('<ProcessSegmentsPage />', () => {
     expect(div.contains('foo')).to.be.true;
     expect(div.contains('bar')).to.be.true;
   });
+
+  it('re renders when agent or process props changes', () => {
+    const props = {
+      fetchSegments: sinon.spy(),
+      agent: 'foo',
+      process: 'bar',
+      segments: { status: statusTypes.LOADED, details: [] }
+    };
+    const processSegmentsPage = mount(<ProcessSegmentsPage {...props} />);
+    processSegmentsPage.setProps({ ...props, agent: 'crazy' });
+    expect(props.fetchSegments.callCount).to.equal(2);
+    expect(props.fetchSegments.getCall(1).args[0]).to.equal('crazy');
+    expect(props.fetchSegments.getCall(1).args[1]).to.equal('bar');
+    processSegmentsPage.setProps({ ...props, process: 'crazy' });
+    expect(props.fetchSegments.callCount).to.equal(3);
+    expect(props.fetchSegments.getCall(2).args[0]).to.equal('foo');
+    expect(props.fetchSegments.getCall(2).args[1]).to.equal('crazy');
+  });
+
+  it('does not re renders when other props changes', () => {
+    const props = {
+      fetchSegments: sinon.spy(),
+      agent: 'foo',
+      process: 'bar',
+      segments: { status: statusTypes.LOADED, details: [] }
+    };
+    const processSegmentsPage = mount(<ProcessSegmentsPage {...props} />);
+    processSegmentsPage.setProps({ ...props, something: 'else' });
+    expect(props.fetchSegments.callCount).to.equal(1);
+  });
 });


### PR DESCRIPTION
this enables re fetching maps or segments when going from `/agent1/processA/segments` to `/agent2/processB/segments` (same for maps)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/98)
<!-- Reviewable:end -->
