### PR TITLE
build: add node v8 in our build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 cache: yarn
 node_js:
   - 6
+  - 8
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0


### PR DESCRIPTION
#96 
Looks like it works out of the box, no code changes needed.
We can start using async/await features now ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/103)
<!-- Reviewable:end -->
