### PR TITLE
angular-mapexplorer: support segments merging

### DIFF
--- a/packages/angular-mapexplorer/docs/home.html
+++ b/packages/angular-mapexplorer/docs/home.html
@@ -19,7 +19,7 @@
         <div class="tip" ng-hide="home.json" layout>
           <span flex>Enter Chainscript JSON</span>
         </div>
-        <st-map-explorer chainscript="home.json" refresh="0" options="home.mapExplorerFromCSOptions"></st-map-explorer>
+        <st-map-explorer chainscript="home.json" agent-url="home.agentUrl" refresh="0" options="home.mapExplorerFromCSOptions"></st-map-explorer>
       </md-tab>
       <md-tab label="Stratumn Application" md-active="home.agentUrl && home.mapId && home.process">
         <div ng-hide="home.segmentShowed['second']">
@@ -75,7 +75,11 @@
   </md-content>
   <svg>
     <marker id="triangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3" orient="auto">
-      <path fill="#CCCCCC" d="M 0 0 L 10 5 L 0 10 z" />
+      <path fill="#999" d="M 0 0 L 10 5 L 0 10 z" />
+    </marker>
+    <marker id="blackTriangle" viewBox="0 0 10 10" refX="0" refY="5" markerUnits="strokeWidth" markerWidth="4" markerHeight="3"
+      orient="auto">
+      <path fill="black" d="M 0 0 L 10 5 L 0 10 z" />
     </marker>
   </svg>
 </div>

--- a/packages/angular-mapexplorer/docs/src/Home.controller.js
+++ b/packages/angular-mapexplorer/docs/src/Home.controller.js
@@ -2,7 +2,7 @@ export default class HomeController {
   constructor($scope, $routeParams, AceConfigurationService) {
     this.$scope = $scope;
     this.mapId = $routeParams.mapId;
-    this.agentUrl = $routeParams.agentUrl;
+    this.agentUrl = $routeParams.agentUrl || 'http://localhost:3000';
     this.process = $routeParams.process;
     this.counter = 0;
 

--- a/packages/angular-mapexplorer/docs/styles/main.css
+++ b/packages/angular-mapexplorer/docs/styles/main.css
@@ -3,18 +3,13 @@
   height: 400px;
 }
 
-.link {
-  fill: none;
-  stroke: #ccc;
-  stroke-width: 1.5px;
-}
 .win polygon {
   stroke: red;
 }
 
 h2 {
   text-transform: uppercase;
-  font-family: 'Open Sans', sans-serif;
+  font-family: "Open Sans", sans-serif;
   font-weight: 600;
   font-size: 18px;
   color: #111111;
@@ -22,64 +17,70 @@ h2 {
 }
 
 .tip {
-    font-family: Gibson-Regular, 'Montserrat', sans-serif;
-    font-size: 42px;
-    color: #E3E3E3;
+  font-family: Gibson-Regular, "Montserrat", sans-serif;
+  font-size: 42px;
+  color: #e3e3e3;
 }
 
 .tip span {
-    /* margin: auto; */
-    text-align: center;
+  /* margin: auto; */
+  text-align: center;
 }
 
 .form {
-    background: #F3F3F3;
-    padding: 0 200px 20px 200px;
+  background: #f3f3f3;
+  padding: 0 200px 20px 200px;
 }
 
 .form label {
-    font-family: Gibson-SemiBold, 'Montserrat', sans-serif;
-    font-weight: 600;
-    font-size: 11px;
-    color: #ADADAD;
-    text-transform: uppercase;
-    margin-bottom: 8px;
+  font-family: Gibson-SemiBold, "Montserrat", sans-serif;
+  font-weight: 600;
+  font-size: 11px;
+  color: #adadad;
+  text-transform: uppercase;
+  margin-bottom: 8px;
 }
 
 .form input {
-    margin-right: 10px;
-    background-color: white;
-    border: none;
-    padding-left: 5px;
-    height: 40px;
+  margin-right: 10px;
+  background-color: white;
+  border: none;
+  padding-left: 5px;
+  height: 40px;
 }
 
 .form .md-button.primary {
-    font-family: Gibson-Regular, 'Montserrat', sans-serif;
-    font-size: 15px;
-    color: #FFFFFF;
-    background: #EC714A;
-    border-radius: 4px;
-    margin-top: 15px;
-    margin-bottom: 0;
+  font-family: Gibson-Regular, "Montserrat", sans-serif;
+  font-size: 15px;
+  color: #ffffff;
+  background: #ec714a;
+  border-radius: 4px;
+  margin-top: 15px;
+  margin-bottom: 0;
 }
 
-a.md-button.md-default-theme.md-fab, a.md-button.md-fab, .md-button.md-default-theme.md-fab,
+a.md-button.md-default-theme.md-fab,
+a.md-button.md-fab,
+.md-button.md-default-theme.md-fab,
 .md-button.md-fab {
-    background: #7BC0D2;
+  background: #7bc0d2;
 }
 
-a.md-button.md-default-theme.md-primary.md-raised, a.md-button.md-primary.md-raised,
-a.md-button.md-default-theme.md-primary.md-fab, a.md-button.md-primary.md-fab,
-.md-button.md-default-theme.md-primary.md-raised, .md-button.md-primary.md-raised,
-.md-button.md-default-theme.md-primary.md-fab, .md-button.md-primary.md-fab {
-    background: #EC714A;
+a.md-button.md-default-theme.md-primary.md-raised,
+a.md-button.md-primary.md-raised,
+a.md-button.md-default-theme.md-primary.md-fab,
+a.md-button.md-primary.md-fab,
+.md-button.md-default-theme.md-primary.md-raised,
+.md-button.md-primary.md-raised,
+.md-button.md-default-theme.md-primary.md-fab,
+.md-button.md-primary.md-fab {
+  background: #ec714a;
 }
 
 st-map-explorer {
-    overflow: scroll;
+  overflow: scroll;
 }
 
 .scroll {
-    overflow: scroll;
+  overflow: scroll;
 }

--- a/packages/angular-mapexplorer/docs/styles/map.css
+++ b/packages/angular-mapexplorer/docs/styles/map.css
@@ -1,36 +1,87 @@
 .node {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .node polygon {
-    fill: #7BC0D2;
+  fill: #7bc0d2;
 }
 
 .node text {
-    font-family: 'RationalTWText-SemiBold', 'Roboto Mono', monospace;
-    font-size: 14px;
-    fill: #FFFFFF;
+  font-family: "RationalTWText-SemiBold", "Roboto Mono", monospace;
+  font-size: 14px;
+  fill: #ffffff;
 }
 
 .node rect {
-    fill: #459FB7;
+  fill: #459fb7;
 }
 
 .textpath {
-    font-family: 'Gibson-Regular', 'Montserrat', sans-serif;
-    font-size: 14px;
-    fill: #C1C1C1;
+  font-family: "Gibson-Regular", "Montserrat", sans-serif;
+  font-size: 14px;
+  fill: #c1c1c1;
 }
 
 .link {
-    stroke-width: 5px;
-    marker-end: url('#triangle');
+  fill: none;
+  stroke: #999;
+  stroke-width: 5px;
+  marker-end: url("#triangle");
 }
 
 .node.selected polygon {
-    fill: #3E3E3E;
+  fill: #3e3e3e;
 }
 
 .node.selected rect {
-    fill: #2E2E2E;
+  fill: #2e2e2e;
+}
+
+path .link.ref:hover {
+  stroke: #000;
+  cursor: pointer;
+}
+
+text #ref-link-text:hover {
+  fill: #000;
+  cursor: pointer;
+  font-size: 24px;
+}
+
+.node.childRef polygon {
+  fill: #cd5c5c;
+}
+
+.node.childRef rect {
+  fill: #8b0000;
+}
+
+.node.ref polygon {
+  fill: #cd5c5c;
+}
+
+.node.ref rect {
+  fill: #8b0000;
+}
+
+#ref-link {
+  stroke-width: 8;
+}
+
+#ref-link:hover {
+  stroke: black;
+  cursor: pointer;
+  stroke-width: 10;
+  marker-end: url("#blackTriangle");
+}
+
+text#linkLabelRef {
+  cursor: pointer;
+  font-family: "RationalTWText-SemiBold", "Roboto Mono", monospace;
+  fill: white;
+}
+
+rect.refLinkBox {
+  cursor: pointer;
+  fill: #8b0000;
 }

--- a/packages/angular-mapexplorer/src/ChainTreeBuilder.service.js
+++ b/packages/angular-mapexplorer/src/ChainTreeBuilder.service.js
@@ -22,8 +22,8 @@ export default class ChainTreeBuilderService {
     this.ChainTreeBuilder = ChainTreeBuilder;
   }
 
-  getBuilder(element) {
-    return new this.ChainTreeBuilder(element);
+  getBuilder(element, options) {
+    return new this.ChainTreeBuilder(element, options);
   }
 
   build(builder, map, options) {

--- a/packages/angular-mapexplorer/src/stMapExplorer.directive.js
+++ b/packages/angular-mapexplorer/src/stMapExplorer.directive.js
@@ -45,7 +45,10 @@ export default function stMapExplorer(ChainTreeBuilderService) {
 
       scope.tags = [];
       const elem = angular.element(element[0].querySelector('.scroll'))[0];
-      const builder = ChainTreeBuilderService.getBuilder(elem);
+      const builder = ChainTreeBuilderService.getBuilder(
+        elem,
+        Object.assign({}, defaultOptions, scope.options)
+      );
 
       const update = () => {
         const options = Object.assign({}, defaultOptions, scope.options);

--- a/packages/mapexplorer-core/src/ChainTreeBuilder.js
+++ b/packages/mapexplorer-core/src/ChainTreeBuilder.js
@@ -73,10 +73,14 @@ export default class ChainTreeBuilder {
     this.chainTree = new ChainTree(element, this.options);
   }
 
-  build(map) {
-    this.options = Object.assign(this.options, {
-      agentUrl: map.agentUrl
-    });
+  build(map, options) {
+    this.options = Object.assign(
+      this.options,
+      {
+        agentUrl: map.agentUrl
+      },
+      options
+    );
     if (map.id && map.agentUrl && map.process) {
       return load(map).then(segments => this.display(segments));
     } else if (map.chainscript && map.chainscript.length) {


### PR DESCRIPTION
@such I had to change what we discussed about sending the map-explorer `options` to the `ChainTreeBuilder` constructor : it is still the case but since angular-mapexplorer can modify the options dynamically, it is now possible (again) to update them by calling `ChainTreeBuilder(map, options)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/111)
<!-- Reviewable:end -->
