### PR TITLE
agent-ui: append segment dialog lists actions

### DIFF
--- a/packages/agent-ui/src/actions/appendSegment.js
+++ b/packages/agent-ui/src/actions/appendSegment.js
@@ -18,18 +18,19 @@ const appendSegmentClear = () => ({
   type: actionTypes.APPEND_SEGMENT_CLEAR
 });
 
-export const openDialog = (
-  agentName,
-  processName,
-  processActions,
-  parentLinkHash
-) => ({
-  type: actionTypes.APPEND_SEGMENT_DIALOG_OPEN,
-  agent: agentName,
-  process: processName,
-  actions: processActions,
-  parent: parentLinkHash
-});
+export const openDialog = (agentName, processName) => (dispatch, getState) => {
+  const { agents } = getState();
+  if (agents[agentName] && agents[agentName].processes[processName]) {
+    const { actions } = agents[agentName].processes[processName];
+    dispatch({
+      type: actionTypes.APPEND_SEGMENT_DIALOG_OPEN,
+      agent: agentName,
+      process: processName,
+      actions: actions,
+      parent: ''
+    });
+  }
+};
 
 export const selectAction = actionName => ({
   type: actionTypes.APPEND_SEGMENT_DIALOG_SELECT_ACTION,

--- a/packages/agent-ui/src/components/appendSegmentButton.js
+++ b/packages/agent-ui/src/components/appendSegmentButton.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const AppendSegmentButton = ({ agent, process, id: mapId, openDialog }) => (
+const AppendSegmentButton = ({ agent, process, openDialog }) => (
   <div style={{ display: 'inline-block', position: 'absolute', right: 0 }}>
     <button
       onClick={e => {
         e.preventDefault();
-        openDialog(agent, process, mapId);
+        openDialog(agent, process);
       }}
     >
       Append
@@ -17,7 +17,6 @@ const AppendSegmentButton = ({ agent, process, id: mapId, openDialog }) => (
 AppendSegmentButton.propTypes = {
   agent: PropTypes.string.isRequired,
   process: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
   openDialog: PropTypes.func.isRequired
 };
 

--- a/packages/agent-ui/src/components/appendSegmentButton.test.js
+++ b/packages/agent-ui/src/components/appendSegmentButton.test.js
@@ -13,16 +13,11 @@ describe('<AppendSegmentButton />', () => {
   it('opens dialog with agent, process and mapId when clicked', () => {
     const openDialogSpy = sinon.spy();
     const appendSegmentButton = mount(
-      <AppendSegmentButton
-        agent="a"
-        process="p"
-        id="m"
-        openDialog={openDialogSpy}
-      />
+      <AppendSegmentButton agent="a" process="p" openDialog={openDialogSpy} />
     );
 
     appendSegmentButton.find('button').simulate('click');
     expect(openDialogSpy.callCount).to.equal(1);
-    expect(openDialogSpy.getCall(0).args).to.deep.equal(['a', 'p', 'm']);
+    expect(openDialogSpy.getCall(0).args).to.deep.equal(['a', 'p']);
   });
 });

--- a/packages/agent-ui/src/containers/app.js
+++ b/packages/agent-ui/src/containers/app.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom';
 
-import { TopBar, LeftNavigation, ContentPage, CreateMapDialog } from './';
+import {
+  TopBar,
+  LeftNavigation,
+  ContentPage,
+  CreateMapDialog,
+  AppendSegmentDialog
+} from './';
 
 export const App = () => (
   <div>
@@ -9,6 +15,7 @@ export const App = () => (
     <LeftNavigation />
     <ContentPage />
     <CreateMapDialog />
+    <AppendSegmentDialog />
   </div>
 );
 

--- a/packages/agent-ui/src/containers/appendSegmentDialog.js
+++ b/packages/agent-ui/src/containers/appendSegmentDialog.js
@@ -6,13 +6,7 @@ import * as statusTypes from '../constants/status';
 
 import { closeAppendSegmentDialogAndClear } from '../actions';
 
-export const AppendSegmentDialog = ({
-  show,
-  actions,
-  selectedAction,
-  error,
-  closeDialog
-}) => {
+export const AppendSegmentDialog = ({ show, actions, error, closeDialog }) => {
   if (!show) {
     return null;
   }
@@ -73,15 +67,13 @@ export const AppendSegmentDialog = ({
 
 AppendSegmentDialog.defaultProps = {
   error: '',
-  actions: {},
-  selectedAction: ''
+  actions: {}
 };
 AppendSegmentDialog.propTypes = {
   show: PropTypes.bool.isRequired,
   /* eslint-disable react/forbid-prop-types */
   actions: PropTypes.object,
   /* eslint-enable react/forbid-prop-types */
-  selectedAction: PropTypes.string,
   error: PropTypes.string,
   closeDialog: PropTypes.func.isRequired
 };

--- a/packages/agent-ui/src/containers/appendSegmentDialog.js
+++ b/packages/agent-ui/src/containers/appendSegmentDialog.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import * as statusTypes from '../constants/status';
+
+import { closeAppendSegmentDialogAndClear } from '../actions';
+
+export const AppendSegmentDialog = ({ show, error, closeDialog }) => {
+  if (!show) {
+    return null;
+  }
+
+  const backdropStyle = {
+    position: 'fixed',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    padding: 50
+  };
+
+  const modalStyle = {
+    backgroundColor: '#fff',
+    borderRadius: 5,
+    maxWidth: 500,
+    minHeight: 300,
+    margin: '0 auto',
+    padding: 30
+  };
+
+  return (
+    <div className="backdrop" style={backdropStyle}>
+      <div className="modal" style={modalStyle}>
+        <div>
+          Append segment
+          <button
+            onClick={e => {
+              e.preventDefault();
+              closeDialog();
+            }}
+          >
+            X
+          </button>
+        </div>
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+          }}
+        >
+          <button type="submit">Append</button>
+          {error && <div className="error">{error}</div>}
+        </form>
+      </div>
+    </div>
+  );
+};
+
+AppendSegmentDialog.defaultProps = {
+  error: ''
+};
+AppendSegmentDialog.propTypes = {
+  show: PropTypes.bool.isRequired,
+  error: PropTypes.string,
+  closeDialog: PropTypes.func.isRequired
+};
+
+export function mapStateToProps(state) {
+  const show = !!(
+    state.appendSegment &&
+    state.appendSegment.dialog &&
+    state.appendSegment.dialog.show
+  );
+
+  if (
+    show &&
+    state.appendSegment.request &&
+    state.appendSegment.request.error &&
+    state.appendSegment.request.status === statusTypes.FAILED
+  ) {
+    return {
+      show,
+      error: state.appendSegment.request.error.toString()
+    };
+  }
+
+  return {
+    show
+  };
+}
+
+export default connect(mapStateToProps, {
+  closeDialog: closeAppendSegmentDialogAndClear
+})(AppendSegmentDialog);

--- a/packages/agent-ui/src/containers/appendSegmentDialog.js
+++ b/packages/agent-ui/src/containers/appendSegmentDialog.js
@@ -6,7 +6,13 @@ import * as statusTypes from '../constants/status';
 
 import { closeAppendSegmentDialogAndClear } from '../actions';
 
-export const AppendSegmentDialog = ({ show, error, closeDialog }) => {
+export const AppendSegmentDialog = ({
+  show,
+  actions,
+  selectedAction,
+  error,
+  closeDialog
+}) => {
   if (!show) {
     return null;
   }
@@ -49,6 +55,14 @@ export const AppendSegmentDialog = ({ show, error, closeDialog }) => {
             e.preventDefault();
           }}
         >
+          <select>
+            {Object.keys(actions).map(a => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+          <br />
           <button type="submit">Append</button>
           {error && <div className="error">{error}</div>}
         </form>
@@ -58,10 +72,16 @@ export const AppendSegmentDialog = ({ show, error, closeDialog }) => {
 };
 
 AppendSegmentDialog.defaultProps = {
-  error: ''
+  error: '',
+  actions: {},
+  selectedAction: ''
 };
 AppendSegmentDialog.propTypes = {
   show: PropTypes.bool.isRequired,
+  /* eslint-disable react/forbid-prop-types */
+  actions: PropTypes.object,
+  /* eslint-enable react/forbid-prop-types */
+  selectedAction: PropTypes.string,
   error: PropTypes.string,
   closeDialog: PropTypes.func.isRequired
 };
@@ -73,8 +93,13 @@ export function mapStateToProps(state) {
     state.appendSegment.dialog.show
   );
 
+  if (!show) {
+    return {
+      show
+    };
+  }
+
   if (
-    show &&
     state.appendSegment.request &&
     state.appendSegment.request.error &&
     state.appendSegment.request.status === statusTypes.FAILED
@@ -86,7 +111,9 @@ export function mapStateToProps(state) {
   }
 
   return {
-    show
+    show,
+    actions: state.appendSegment.dialog.actions,
+    selectedAction: state.appendSegment.dialog.selectedAction
   };
 }
 

--- a/packages/agent-ui/src/containers/appendSegmentDialog.js
+++ b/packages/agent-ui/src/containers/appendSegmentDialog.js
@@ -78,11 +78,11 @@ AppendSegmentDialog.propTypes = {
   closeDialog: PropTypes.func.isRequired
 };
 
-export function mapStateToProps(state) {
+export function mapStateToProps({ appendSegment }) {
   const show = !!(
-    state.appendSegment &&
-    state.appendSegment.dialog &&
-    state.appendSegment.dialog.show
+    appendSegment &&
+    appendSegment.dialog &&
+    appendSegment.dialog.show
   );
 
   if (!show) {
@@ -92,20 +92,20 @@ export function mapStateToProps(state) {
   }
 
   if (
-    state.appendSegment.request &&
-    state.appendSegment.request.error &&
-    state.appendSegment.request.status === statusTypes.FAILED
+    appendSegment.request &&
+    appendSegment.request.error &&
+    appendSegment.request.status === statusTypes.FAILED
   ) {
     return {
       show,
-      error: state.appendSegment.request.error.toString()
+      error: appendSegment.request.error.toString()
     };
   }
 
   return {
     show,
-    actions: state.appendSegment.dialog.actions,
-    selectedAction: state.appendSegment.dialog.selectedAction
+    actions: appendSegment.dialog.actions,
+    selectedAction: appendSegment.dialog.selectedAction
   };
 }
 

--- a/packages/agent-ui/src/containers/appendSegmentDialog.test.js
+++ b/packages/agent-ui/src/containers/appendSegmentDialog.test.js
@@ -7,21 +7,36 @@ import sinonChai from 'sinon-chai';
 
 import * as statusTypes from '../constants/status';
 
+import { TestProcessBuilder } from '../test/builders/state';
+
 import { AppendSegmentDialog, mapStateToProps } from './appendSegmentDialog';
 
 chai.use(sinonChai);
 
 describe('<AppendSegmentDialog />', () => {
+  const testActions = new TestProcessBuilder('p')
+    .withAction('a1', ['a1_1', 'a1_2'])
+    .withAction('a2', ['a2_1', 'a2_2', 'a2_3'])
+    .build().actions;
+
   const requiredProps = {
     show: true,
+    actions: testActions,
+    selectedAction: 'a2',
     closeDialog: () => {}
   };
 
   it('learns to show dialog from state', () => {
     const props = mapStateToProps({
-      appendSegment: { dialog: { show: true } }
+      appendSegment: {
+        dialog: { show: true, actions: testActions, selectedAction: 'a2' }
+      }
     });
-    expect(props).to.deep.equal({ show: true });
+    expect(props).to.deep.equal({
+      show: true,
+      actions: testActions,
+      selectedAction: 'a2'
+    });
   });
 
   it('does not show dialog if state missing', () => {
@@ -64,5 +79,13 @@ describe('<AppendSegmentDialog />', () => {
     const closeButton = dialog.find('button').at(0);
     closeButton.simulate('click');
     expect(closeDialogSpy.callCount).to.equal(1);
+  });
+
+  it('provides a dropdown to select action', () => {
+    const dialog = shallow(<AppendSegmentDialog {...requiredProps} />);
+    const actions = dialog.find('select');
+    expect(actions.children()).to.have.length(2);
+    expect(actions.childAt(0).text()).to.equal('a1');
+    expect(actions.childAt(1).text()).to.equal('a2');
   });
 });

--- a/packages/agent-ui/src/containers/appendSegmentDialog.test.js
+++ b/packages/agent-ui/src/containers/appendSegmentDialog.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { mount, shallow } from 'enzyme';
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import * as statusTypes from '../constants/status';
+
+import { AppendSegmentDialog, mapStateToProps } from './appendSegmentDialog';
+
+chai.use(sinonChai);
+
+describe('<AppendSegmentDialog />', () => {
+  const requiredProps = {
+    show: true,
+    closeDialog: () => {}
+  };
+
+  it('learns to show dialog from state', () => {
+    const props = mapStateToProps({
+      appendSegment: { dialog: { show: true } }
+    });
+    expect(props).to.deep.equal({ show: true });
+  });
+
+  it('does not show dialog if state missing', () => {
+    const props = mapStateToProps({});
+    expect(props).to.deep.equal({ show: false });
+  });
+
+  it('extracts error from state', () => {
+    const props = mapStateToProps({
+      appendSegment: {
+        dialog: { show: true },
+        request: { status: statusTypes.FAILED, error: 'err!!!' }
+      }
+    });
+    expect(props.error).to.equal('err!!!');
+  });
+
+  it('only extracts error from state if status is failed', () => {
+    const props = mapStateToProps({
+      appendSegment: {
+        dialog: { show: true },
+        request: { status: statusTypes.LOADING, error: 'err!!!' }
+      }
+    });
+    expect(props.error).to.be.undefined;
+  });
+
+  it('does not show if it should not', () => {
+    const dialog = shallow(
+      <AppendSegmentDialog {...requiredProps} show={false} />
+    );
+    expect(dialog.children()).to.have.length(0);
+  });
+
+  it('provides a button to close dialog', () => {
+    const closeDialogSpy = sinon.spy();
+    const dialog = mount(
+      <AppendSegmentDialog {...requiredProps} closeDialog={closeDialogSpy} />
+    );
+    const closeButton = dialog.find('button').at(0);
+    closeButton.simulate('click');
+    expect(closeDialogSpy.callCount).to.equal(1);
+  });
+});

--- a/packages/agent-ui/src/containers/createMapDialog.test.js
+++ b/packages/agent-ui/src/containers/createMapDialog.test.js
@@ -17,6 +17,7 @@ describe('<CreateMapDialog />', () => {
     createMap: () => {},
     closeDialog: () => {}
   };
+
   it('learns to show dialog from state', () => {
     const props = mapStateToProps({ createMap: { dialog: { show: true } } });
     expect(props).to.deep.equal({ show: true });

--- a/packages/agent-ui/src/containers/index.js
+++ b/packages/agent-ui/src/containers/index.js
@@ -16,3 +16,4 @@ export { default as ProcessSegmentsPage } from './processSegmentsPage';
 export { default as MapPage } from './mapPage';
 export { default as SegmentPage } from './segmentPage';
 export { default as CreateMapDialog } from './createMapDialog';
+export { default as AppendSegmentDialog } from './appendSegmentDialog';

--- a/packages/agent-ui/src/containers/topBar.js
+++ b/packages/agent-ui/src/containers/topBar.js
@@ -5,7 +5,7 @@ import { withRouter, NavLink, Route } from 'react-router-dom';
 
 import { AppendSegmentButton, CreateMapButton } from '../components';
 
-import { openCreateMapDialog } from '../actions';
+import { openCreateMapDialog, openAppendSegmentDialog } from '../actions';
 
 const renderTopBarLinks = path => {
   const parts = path.split('/').filter(p => p);
@@ -23,7 +23,7 @@ const renderTopBarLinks = path => {
   });
 };
 
-export const TopBar = ({ path, mapDialog }) => {
+export const TopBar = ({ path, mapDialog, segmentDialog }) => {
   const style = {
     position: 'absolute',
     width: 'calc(100% - 240px)',
@@ -51,7 +51,7 @@ export const TopBar = ({ path, mapDialog }) => {
         path="/:agent/:process/maps/:id"
         render={props => (
           <AppendSegmentButton
-            openDialog={() => console.log('Append segment...')}
+            openDialog={segmentDialog}
             {...props.match.params}
           />
         )}
@@ -63,6 +63,7 @@ export const TopBar = ({ path, mapDialog }) => {
 TopBar.propTypes = {
   path: PropTypes.string.isRequired,
   mapDialog: PropTypes.func.isRequired,
+  segmentDialog: PropTypes.func.isRequired,
   /* eslint-disable react/forbid-prop-types */
   match: PropTypes.object.isRequired
   /* eslint-enable react/forbid-prop-types */
@@ -75,5 +76,8 @@ function mapStateToProps(state, ownProps) {
 }
 
 export default withRouter(
-  connect(mapStateToProps, { mapDialog: openCreateMapDialog })(TopBar)
+  connect(mapStateToProps, {
+    mapDialog: openCreateMapDialog,
+    segmentDialog: openAppendSegmentDialog
+  })(TopBar)
 );

--- a/packages/agent-ui/src/containers/topBar.test.js
+++ b/packages/agent-ui/src/containers/topBar.test.js
@@ -12,7 +12,8 @@ import { AppendSegmentButton, CreateMapButton } from '../components';
 describe('<TopBar />', () => {
   const requiredProps = {
     match: { params: { agent: 'a', process: 'p' } },
-    mapDialog: () => {}
+    mapDialog: () => {},
+    segmentDialog: () => {}
   };
 
   const mockStore = configureStore();


### PR DESCRIPTION
Create a basic append segment dialog that can be opened and closed.
List available actions in a dropdown, and populates these actions from state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/120)
<!-- Reviewable:end -->
