### PR TITLE
Save agent version in segment

### DIFF
--- a/packages/agent-js/src/plugins/agentVersion.js
+++ b/packages/agent-js/src/plugins/agentVersion.js
@@ -15,12 +15,6 @@
 */
 import { version } from '../../package.json';
 
-/**
- * Sets agentVersion in the link's meta data using the version
- * from package.json.
- * @param {object} link
- */
-
 export default {
   name: 'Agent Version',
 

--- a/packages/agent-js/src/plugins/agentVersion.js
+++ b/packages/agent-js/src/plugins/agentVersion.js
@@ -13,21 +13,20 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+import { version } from '../../package.json';
 
-import actionArgs from './actionArgs';
-import agentUrl from './agentUrl';
-import encryptedState from './encryptedState';
-import localTime from './localTime';
-import signedState from './signedState';
-import stateHash from './stateHash';
-import agentVersion from './agentVersion';
+/**
+ * Sets agentVersion in the link's meta data using the version
+ * from package.json.
+ * @param {object} link
+ */
 
-module.exports = {
-  actionArgs,
-  agentUrl,
-  agentVersion,
-  encryptedState,
-  localTime,
-  signedState,
-  stateHash
+export default {
+  name: 'Agent Version',
+
+  description: 'Saves the agent version in the link meta information.',
+
+  didCreateLink(link) {
+    link.meta.agentVersion = version;
+  }
 };

--- a/packages/agent-js/test/plugins/agentVersion.js
+++ b/packages/agent-js/test/plugins/agentVersion.js
@@ -14,20 +14,20 @@
   limitations under the License.
 */
 
-import actionArgs from './actionArgs';
-import agentUrl from './agentUrl';
-import encryptedState from './encryptedState';
-import localTime from './localTime';
-import signedState from './signedState';
-import stateHash from './stateHash';
-import agentVersion from './agentVersion';
+import pluginTest from '.';
+import agentVersion from '../../src/plugins/agentVersion';
+import { version } from '../../package.json';
 
-module.exports = {
-  actionArgs,
-  agentUrl,
-  agentVersion,
-  encryptedState,
-  localTime,
-  signedState,
-  stateHash
-};
+function test(segment) {
+  segment.link.meta.agentVersion.should.equal(version);
+}
+
+pluginTest(agentVersion, {
+  '#createMap()'(segment) {
+    test(segment);
+  },
+
+  '#createSegment()'(segment) {
+    test(segment);
+  }
+});

--- a/packages/angular-mapexplorer/.gitignore
+++ b/packages/angular-mapexplorer/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 pids
 logs
 results
+coverage
 
 node_modules
 


### PR DESCRIPTION
This adds a plugin to save the agent version in the segments `link.meta` object. 

I also noticed when bootstrapping this project that the `yarn.lock` file of the agent-ui was updated. That is included in a separate commit. Not sure if this PR is the appropriate place for that but we should probably update the lock file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/123)
<!-- Reviewable:end -->
