### PR TITLE
agent-ui: don't show the init action when appending a segment

### DIFF
--- a/packages/agent-ui/src/actions/appendSegment.js
+++ b/packages/agent-ui/src/actions/appendSegment.js
@@ -22,16 +22,15 @@ const appendSegmentClear = () => ({
 export const openDialog = (agentName, processName) => (dispatch, getState) => {
   const { agents, mapExplorer: { linkHash } } = getState();
   if (agents[agentName] && agents[agentName].processes[processName]) {
-    const actions = JSON.parse(
-      JSON.stringify(agents[agentName].processes[processName].actions)
-    );
-    delete actions.init;
+    const { init, ...segmentActions } = agents[agentName].processes[
+      processName
+    ].actions;
 
     dispatch({
       type: actionTypes.APPEND_SEGMENT_DIALOG_OPEN,
       agent: agentName,
       process: processName,
-      actions: actions,
+      actions: segmentActions,
       parent: linkHash
     });
   }

--- a/packages/agent-ui/src/actions/appendSegment.js
+++ b/packages/agent-ui/src/actions/appendSegment.js
@@ -22,7 +22,11 @@ const appendSegmentClear = () => ({
 export const openDialog = (agentName, processName) => (dispatch, getState) => {
   const { agents, mapExplorer: { linkHash } } = getState();
   if (agents[agentName] && agents[agentName].processes[processName]) {
-    const { actions } = agents[agentName].processes[processName];
+    const actions = JSON.parse(
+      JSON.stringify(agents[agentName].processes[processName].actions)
+    );
+    delete actions.init;
+
     dispatch({
       type: actionTypes.APPEND_SEGMENT_DIALOG_OPEN,
       agent: agentName,

--- a/packages/agent-ui/src/actions/appendSegment.test.js
+++ b/packages/agent-ui/src/actions/appendSegment.test.js
@@ -33,7 +33,6 @@ describe('open action', () => {
 
   it('finds process actions from agent and process name', () => {
     const process = new TestProcessBuilder('p')
-      .withAction('init', ['title'])
       .withAction('message', ['author', 'text'])
       .build();
     getStateStub.returns(
@@ -53,6 +52,25 @@ describe('open action', () => {
       process: 'p',
       actions: process.actions,
       parent: 'lh'
+    });
+  });
+
+  it('removes the init action if present', () => {
+    const process = new TestProcessBuilder('p')
+      .withAction('init', ['title'])
+      .withAction('message', ['author', 'text'])
+      .build();
+    getStateStub.returns(
+      new TestStateBuilder()
+        .withAgent('a', new TestAgentBuilder().withProcess(process).build())
+        .withSelectedMapExplorerSegment('lh')
+        .build()
+    );
+
+    openDialog('a', 'p')(dispatchSpy, getStateStub);
+    expect(dispatchSpy.callCount).to.equal(1);
+    expect(dispatchSpy.getCall(0).args[0].actions).to.deep.equal({
+      message: { args: ['author', 'text'] }
     });
   });
 


### PR DESCRIPTION
It doesn't make sense to expose the init action when appending to an existing segment.
Init should only be used when creating a new map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/128)
<!-- Reviewable:end -->
