### PR TITLE
agent-js: /processes and /:process/remove resolve with public data

### DIFF
--- a/packages/agent-client-js/src/objectAdaptor.js
+++ b/packages/agent-client-js/src/objectAdaptor.js
@@ -27,7 +27,7 @@ export default class objectAdaptor {
   }
 
   getProcesses() {
-    return Promise.resolve(decorateBody(this.agent.getAllProcesses()));
+    return this.agent.getAllProcesses().then(decorateBody);
   }
 
   createMap(processName, ...args) {

--- a/packages/agent-js/src/create.js
+++ b/packages/agent-js/src/create.js
@@ -108,8 +108,7 @@ export default function create(options) {
     * @returns {Promise} - a promise resolving with the processes' info (indexed by process name)
     */
     getInfo() {
-      const processesInfo = Object.values(processes).map(p => p.getInfo());
-      return Promise.all(processesInfo)
+      return this.getAllProcesses()
         .then(res =>
           res.reduce((map, process) => {
             map[process.name] = process;
@@ -192,14 +191,16 @@ export default function create(options) {
         throw err;
       }
       delete processes[processName];
-      return Object.values(processes);
+      return this.getAllProcesses();
     },
+
     /**
     * Returns the processes.
     * @returns {Array} - an array containing all the processes
     */
     getAllProcesses() {
-      return Object.values(processes);
+      const processesInfo = Object.values(processes).map(p => p.getInfo());
+      return Promise.all(processesInfo);
     },
 
     /**

--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -168,10 +168,9 @@ export default function httpServer(agent, opts = {}) {
    *              $ref: '#/definitions/Process'
    *
    */
-  app.get('/processes', (req, res) => {
-    const processes = agent.getAllProcesses(req.query);
-    return res.json(processes);
-  });
+  app.get('/processes', (req, res) =>
+    agent.getAllProcesses(req.query).then(res.json.bind(res))
+  );
 
   /**
    * This API allows dynamic upload of new processes to a running agent.
@@ -311,8 +310,7 @@ export default function httpServer(agent, opts = {}) {
       agent.addProcess(req.params.process, processActions, store, fossilizers, {
         plugins: plugins
       });
-
-      return res.json(agent.getAllProcesses());
+      return agent.getAllProcesses().then(res.json.bind(res));
     });
   }
 
@@ -337,10 +335,9 @@ export default function httpServer(agent, opts = {}) {
    *       404:
    *         description: Process not found
    */
-  app.get('/:process/remove', (req, res) => {
-    const processes = agent.removeProcess(req.params.process);
-    return res.json(processes);
-  });
+  app.get('/:process/remove', (req, res) =>
+    agent.removeProcess(req.params.process).then(res.json.bind(res))
+  );
 
   /**
    * @swagger


### PR DESCRIPTION
Fix #127 

- The format being used by `agent.getAllProcesses()`is now consistent with the one already in use in `agent.getInfo()`

- Since we are actually querying the store and fossilizers when calling `getAllProcesses` (unlike before), an httpMockServer is now used for testing dynamic process addition. (this is why store/fossilizers urls are set to `http://localhost`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/134)
<!-- Reviewable:end -->
