### PR TITLE
agent-ui: create docker image

### DIFF
--- a/packages/agent-ui/.dockerignore
+++ b/packages/agent-ui/.dockerignore
@@ -1,0 +1,12 @@
+# Items that don't need to be in a Docker image.
+# Anything not used by the build system should go here.
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+
+# Artifacts that will be built during image creation.
+# This should contain all files created during `npm run build`.
+build
+coverage
+node_modules

--- a/packages/agent-ui/Dockerfile
+++ b/packages/agent-ui/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:8
+
+RUN npm install -g yarn
+
+RUN mkdir /agent-ui
+ADD package.json /agent-ui/package.json
+ADD yarn.lock /agent-ui/yarn.lock
+RUN cd /agent-ui; yarn install
+ADD . /agent-ui/
+WORKDIR /agent-ui
+
+ENV NODE_ENV production
+RUN yarn build
+
+RUN npm install -g serve
+CMD serve -s build -p 4000

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -12,7 +12,6 @@
   "bugs": {
     "url": "https://github.com/stratumn/indigo-js/issues"
   },
-  "homepage": "https://github.com/stratumn/indigo-js",
   "keywords": ["stratumn", "agent", "blockchain"],
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Create a docker image with agent-ui running in it.
The image created looks good but at runtime there is an issue with radium.
I suspect it's because we haven't pushed recent versions of the other indigo JS packages to npm (map-explorer especially) and the docker image gets an outdated radium version incompatible with the latest react.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/138)
<!-- Reviewable:end -->
