### PR TITLE
agent-ui: short segment hash

### DIFF
--- a/packages/agent-ui/src/containers/topBar.js
+++ b/packages/agent-ui/src/containers/topBar.js
@@ -11,6 +11,7 @@ import layout from '../styles/layout';
 
 import { TopBarButton } from '../components';
 import { openCreateMapDialog, openAppendSegmentDialog } from '../actions';
+import shortHash from '../utils/shortHash';
 
 const renderTopBarLinks = path => {
   if (!path || path === '/') {
@@ -22,6 +23,10 @@ const renderTopBarLinks = path => {
   }
 
   const parts = path.split('/').filter(p => p);
+  // shorten the segment linkHash in the topbar breadcrumbs display
+  if (parts.length === 4 && parts[2] === 'segments') {
+    parts[3] = shortHash(parts[3]);
+  }
   let currentLink = '';
 
   // Note: typography automatically removes trailing whitespaces and requires

--- a/packages/agent-ui/src/containers/topBar.test.js
+++ b/packages/agent-ui/src/containers/topBar.test.js
@@ -77,4 +77,28 @@ describe('<TopBar />', () => {
     );
     verifyButton(topBarWithAppendSegment, 'Append');
   });
+
+  it('renders short hash for segment id', () => {
+    const topBarWithLinks = renderTopBarWithRoute(
+      '/agent/process/segments/thisIsALongStringThatShouldBeShorter'
+    );
+
+    const navLinks = topBarWithLinks.find(NavLink);
+    expect(navLinks).to.have.length(4);
+
+    expect(navLinks.at(3).text()).to.equal('thisIsAL..er');
+  });
+
+  it('renders full hash for map id', () => {
+    const topBarWithLinks = renderTopBarWithRoute(
+      '/agent/process/maps/thisIsALongStringThatShouldBeShorter'
+    );
+
+    const navLinks = topBarWithLinks.find(NavLink);
+    expect(navLinks).to.have.length(4);
+
+    expect(navLinks.at(3).text()).to.equal(
+      'thisIsALongStringThatShouldBeShorter'
+    );
+  });
 });

--- a/packages/agent-ui/src/utils/shortHash.js
+++ b/packages/agent-ui/src/utils/shortHash.js
@@ -1,0 +1,5 @@
+export default function(hash) {
+  return hash.length > 12
+    ? `${hash.substr(0, 8)}..${hash.substr(hash.length - 2)}`
+    : hash;
+}

--- a/packages/agent-ui/src/utils/shortHash.test.js
+++ b/packages/agent-ui/src/utils/shortHash.test.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import shortHash from './shortHash';
+
+describe('shortHash()', () => {
+  it('shorten the hash when too long', () => {
+    const h =
+      '387b5d41024cb8b99d6d4baec3d2651e0999e73e51ee88df01496d08917a3b65';
+    const expected = '387b5d41..65';
+    expect(shortHash(h)).to.equal(expected);
+  });
+
+  it('shorten the hash when exactly 13 chars long', () => {
+    const h = '387b5d41024cb';
+    const expected = '387b5d41..cb';
+    expect(shortHash(h)).to.equal(expected);
+  });
+
+  it('does not shorten the hash when 12 chars or less', () => {
+    const h12 = '387b5d41024c';
+    expect(shortHash(h12)).to.equal(h12);
+    const h5 = '387b5';
+    expect(shortHash(h5)).to.equal(h5);
+  });
+});


### PR DESCRIPTION
display short segment hash in top bar instead of full hash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/143)
<!-- Reviewable:end -->
