### PR TITLE
agent-ui: validate prev link hash filter

### DIFF
--- a/packages/agent-ui/src/components/segmentsFilter.js
+++ b/packages/agent-ui/src/components/segmentsFilter.js
@@ -6,6 +6,7 @@ import Table, { TableBody, TableCell, TableRow } from 'material-ui/Table';
 import TextField from 'material-ui/TextField';
 import { withStyles } from 'material-ui/styles';
 import tableStyle from '../styles/tables';
+import { validateHash } from '../utils/hashUtils';
 
 const checkAndJoin = o => {
   if (Array.isArray(o)) {
@@ -18,6 +19,9 @@ const checkAndTrim = s => s && s.trim();
 
 const checkTrimAndSplit = s => s && s.trim().split(' ');
 
+const validatePrevLinkHash = s =>
+  s === undefined || s === '' || validateHash(s);
+
 export class SegmentsFilter extends Component {
   constructor(props) {
     super(props);
@@ -26,10 +30,12 @@ export class SegmentsFilter extends Component {
     this.state = {
       mapIds: checkAndJoin(mapIds),
       tags: checkAndJoin(tags),
-      prevLinkHash
+      prevLinkHash,
+      valid: validatePrevLinkHash(prevLinkHash)
     };
 
     this.handleChange = this.handleChange.bind(this);
+    this.handlePrevLinkHashChange = this.handlePrevLinkHashChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleClear = this.handleClear.bind(this);
   }
@@ -40,12 +46,21 @@ export class SegmentsFilter extends Component {
     this.setState({
       mapIds: checkAndJoin(mapIds),
       tags: checkAndJoin(tags),
-      prevLinkHash
+      prevLinkHash,
+      valid: validatePrevLinkHash(prevLinkHash)
     });
   }
 
   handleChange(key, value) {
     this.setState({ ...this.state, [key]: value });
+  }
+
+  handlePrevLinkHashChange(value) {
+    this.setState({
+      ...this.state,
+      prevLinkHash: value,
+      valid: validatePrevLinkHash(value)
+    });
   }
 
   handleSubmit(e) {
@@ -61,6 +76,7 @@ export class SegmentsFilter extends Component {
   handleClear(e) {
     e.preventDefault();
     this.props.submitHandler({});
+    // this.setState({});
   }
 
   render() {
@@ -83,8 +99,8 @@ export class SegmentsFilter extends Component {
                 label="Prev link hash"
                 value={this.state.prevLinkHash || ''}
                 type="text"
-                onChange={e =>
-                  this.handleChange('prevLinkHash', e.target.value)}
+                error={!this.state.valid}
+                onChange={e => this.handlePrevLinkHashChange(e.target.value)}
               />
             </TableCell>
             <TableCell>
@@ -96,7 +112,11 @@ export class SegmentsFilter extends Component {
               />
             </TableCell>
             <TableCell>
-              <Button type="filter" onClick={this.handleSubmit}>
+              <Button
+                type="filter"
+                onClick={this.handleSubmit}
+                disabled={!this.state.valid}
+              >
                 Filter
               </Button>
             </TableCell>

--- a/packages/agent-ui/src/components/segmentsFilter.test.js
+++ b/packages/agent-ui/src/components/segmentsFilter.test.js
@@ -5,10 +5,12 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import { SegmentsFilter } from './segmentsFilter';
+import * as hashUtils from '../utils/hashUtils';
 
 chai.use(sinonChai);
 
 describe('<SegmentsFilter />', () => {
+  let validateHashStub;
   const submitSpy = sinon.spy();
   const requiredProps = {
     filters: {},
@@ -20,6 +22,12 @@ describe('<SegmentsFilter />', () => {
 
   beforeEach(() => {
     submitSpy.reset();
+    validateHashStub = sinon.stub(hashUtils, 'validateHash');
+    validateHashStub.returns(true);
+  });
+
+  afterEach(() => {
+    validateHashStub.restore();
   });
 
   it('renders the filters correctly', () => {
@@ -127,5 +135,19 @@ describe('<SegmentsFilter />', () => {
       prevLinkHash: 'xyz',
       tags: ['foo', 'bar']
     });
+  });
+
+  it('disable filter button and show error when prevLinkHash not valid', () => {
+    validateHashStub.returns(false);
+    const props = {
+      filters: {
+        prevLinkHash: 'xyz'
+      }
+    };
+    const segmentsFilter = renderComponent(props);
+    const filterBtn = segmentsFilter.find('Button[type="filter"]');
+    expect(filterBtn.props().disabled).to.be.true;
+    const prevLinkHashFld = segmentsFilter.find('[label="Prev link hash"]');
+    expect(prevLinkHashFld.props().error).to.be.true;
   });
 });

--- a/packages/agent-ui/src/containers/processSegmentsPage.test.js
+++ b/packages/agent-ui/src/containers/processSegmentsPage.test.js
@@ -11,10 +11,22 @@ import { SegmentsFilter } from '../components/segmentsFilter';
 import { SegmentsList } from '../components/segmentsList';
 import * as statusTypes from '../constants/status';
 import history from '../store/history';
+import * as hashUtils from '../utils/hashUtils';
 
 chai.use(sinonChai);
 
 describe('<ProcessSegmentsPage />', () => {
+  let validateHashStub;
+
+  beforeEach(() => {
+    validateHashStub = sinon.stub(hashUtils, 'validateHash');
+    validateHashStub.returns(true);
+  });
+
+  afterEach(() => {
+    validateHashStub.restore();
+  });
+
   const requiredProps = {
     agent: '',
     process: '',

--- a/packages/agent-ui/src/containers/topBar.js
+++ b/packages/agent-ui/src/containers/topBar.js
@@ -11,7 +11,7 @@ import layout from '../styles/layout';
 
 import { TopBarButton } from '../components';
 import { openCreateMapDialog, openAppendSegmentDialog } from '../actions';
-import shortHash from '../utils/shortHash';
+import { shortHash } from '../utils/hashUtils';
 
 const renderTopBarLinks = path => {
   if (!path || path === '/') {

--- a/packages/agent-ui/src/utils/hashUtils.js
+++ b/packages/agent-ui/src/utils/hashUtils.js
@@ -1,0 +1,6 @@
+export const shortHash = hash =>
+  hash.length > 12
+    ? `${hash.substr(0, 8)}..${hash.substr(hash.length - 2)}`
+    : hash;
+
+export const validateHash = hash => /^[a-zA-Z0-9]{64}$/.test(hash);

--- a/packages/agent-ui/src/utils/hashUtils.test.js
+++ b/packages/agent-ui/src/utils/hashUtils.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import shortHash from './shortHash';
+import { shortHash, validateHash } from './hashUtils';
 
 describe('shortHash()', () => {
   it('shorten the hash when too long', () => {
@@ -20,5 +20,19 @@ describe('shortHash()', () => {
     expect(shortHash(h12)).to.equal(h12);
     const h5 = '387b5';
     expect(shortHash(h5)).to.equal(h5);
+  });
+});
+
+describe('validateHash()', () => {
+  it('validates', () => {
+    expect(
+      validateHash(
+        '12c571bce42a3400a315ed4f86c008a5ae055b90386c0a892103f1d4cd022acc'
+      )
+    ).to.be.true;
+  });
+
+  it('does not validate', () => {
+    expect(validateHash('abc123')).to.be.false;
   });
 });

--- a/packages/agent-ui/src/utils/shortHash.js
+++ b/packages/agent-ui/src/utils/shortHash.js
@@ -1,5 +1,0 @@
-export default function(hash) {
-  return hash.length > 12
-    ? `${hash.substr(0, 8)}..${hash.substr(hash.length - 2)}`
-    : hash;
-}


### PR DESCRIPTION
validate previous link hash filter (should be a 64 char long string) and prevent from filtering and show error when invalid