### PR TITLE
*: ignore package.json with prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json


### PR DESCRIPTION
Since package.json are already formatted by yarn, they should not be formatted by prettier. It can make actual changes harder to detect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/162)
<!-- Reviewable:end -->
