### PR TITLE
agent-ui: Fix selectRefsDialog for undef agent

### DIFF
--- a/packages/agent-ui/src/containers/selectRefsDialog.js
+++ b/packages/agent-ui/src/containers/selectRefsDialog.js
@@ -115,9 +115,9 @@ SelectRefsDialog.propTypes = {
 function mapStateToProps(state, ownProps) {
   const { location: { pathname } } = ownProps;
   const { process, agent } = parseAgentAndProcess(pathname);
-  const { segments, selectRefs: { show } } = state;
-  const { agents: { [agent]: { processes } } } = state;
-  return { agent, process, segments, show, processes: Object.keys(processes) };
+  const { segments, selectRefs: { show }, agents } = state;
+  const processes = agents[agent] ? Object.keys(agents[agent].processes) : [];
+  return { agent, process, segments, show, processes };
 }
 
 export default connect(mapStateToProps, {


### PR DESCRIPTION
In some cases, the agent can not be initialized in the store

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/163)
<!-- Reviewable:end -->
