### PR TITLE
agent-ui: add websocket notifications

### DIFF
--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -53,6 +53,7 @@
     "enzyme-adapter-react-16": "^1.1.0",
     "eslint": "^4.8.0",
     "eslint-plugin-react": "^7.4.0",
+    "mock-socket": "^7.1.0",
     "react-scripts": "^1.0.17",
     "react-test-renderer": "^16.0.0",
     "redux-mock-store": "^1.3.0",

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -12,19 +12,17 @@
   "bugs": {
     "url": "https://github.com/stratumn/indigo-js/issues"
   },
-  "keywords": [
-    "stratumn",
-    "agent",
-    "blockchain"
-  ],
+  "keywords": ["stratumn", "agent", "blockchain"],
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "test:ci": "react-scripts build && CI=true react-scripts test --env=jsdom --coverage",
+    "test:ci":
+      "react-scripts build && CI=true react-scripts test --env=jsdom --coverage",
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "history": "^4.7.2",
     "immutable": "^3.8.2",
     "material-ui": "^1.0.0-beta.21",
@@ -46,7 +44,6 @@
     "uuid": "^3.1.0"
   },
   "devDependencies": {
-    "babel-polyfill": "^6.26.0",
     "chai": "^4.1.2",
     "css.escape": "^1.5.1",
     "enzyme": "^3.1.0",

--- a/packages/agent-ui/src/actions/appendSegment.js
+++ b/packages/agent-ui/src/actions/appendSegment.js
@@ -73,11 +73,7 @@ export const appendSegment = (...args) => (dispatch, getState) => {
         dispatch(appendSegmentSuccess(segment));
         dispatch(closeDialog());
         dispatch(clearRefs());
-        dispatch(
-          addNotifications([
-            makeNewSegmentNotification(agent, process, segment)
-          ])
-        );
+        dispatch(addNotifications([makeNewSegmentNotification(segment)]));
       })
       .catch(err => {
         dispatch(appendSegmentFailure(err));

--- a/packages/agent-ui/src/actions/getAgent.js
+++ b/packages/agent-ui/src/actions/getAgent.js
@@ -1,5 +1,6 @@
 import { getAgent as getAgentClient } from 'stratumn-agent-client';
 import * as actionTypes from '../constants/actionTypes';
+import { openWebSocket, closeWebSocket } from '../utils/webSocketHelpers';
 
 const getAgentRequest = (name, url) => ({
   type: actionTypes.AGENT_INFO_REQUEST,
@@ -19,14 +20,18 @@ const getAgentSuccess = (name, agent) => ({
   agent
 });
 
-export const removeAgent = name => ({
-  type: actionTypes.AGENT_INFO_DELETE,
-  name
-});
+export const removeAgent = name => {
+  closeWebSocket(name);
+  return {
+    type: actionTypes.AGENT_INFO_DELETE,
+    name
+  };
+};
 
 export const getAgent = (name, url) => dispatch => {
   dispatch(getAgentRequest(name, url));
   return getAgentClient(url)
     .then(agent => dispatch(getAgentSuccess(name, agent)))
+    .then(() => openWebSocket(name, url, dispatch))
     .catch(err => dispatch(getAgentFailure(name, err)));
 };

--- a/packages/agent-ui/src/actions/getAgent.test.js
+++ b/packages/agent-ui/src/actions/getAgent.test.js
@@ -6,20 +6,24 @@ import sinonChai from 'sinon-chai';
 
 import { getAgent, removeAgent } from './getAgent';
 import * as actionTypes from '../constants/actionTypes';
+import * as webSocket from '../utils/webSocketHelpers';
 
 chai.use(sinonChai);
 
 describe('getAgent action', () => {
   let stratumnClientStub;
+  let openWsStub;
   let dispatchSpy;
 
   beforeEach(() => {
     stratumnClientStub = sinon.stub(StratumnAgentClient, 'getAgent');
+    openWsStub = sinon.stub(webSocket, 'openWebSocket');
     dispatchSpy = sinon.spy();
   });
 
   afterEach(() => {
     stratumnClientStub.restore();
+    openWsStub.restore();
   });
 
   it('calls stratumn client to get agent', () => {

--- a/packages/agent-ui/src/constants/notificationTypes.js
+++ b/packages/agent-ui/src/constants/notificationTypes.js
@@ -1,0 +1,3 @@
+export const NEW_SEGMENT = 'NEW_SEGMENT';
+export const NEW_MAP = 'NEW_MAP';
+export const NEW_USER = 'NEW_USER';

--- a/packages/agent-ui/src/containers/app.js
+++ b/packages/agent-ui/src/containers/app.js
@@ -11,7 +11,8 @@ import {
   ContentPage,
   CreateMapDialog,
   AppendSegmentDialog,
-  SelectRefsDialog
+  SelectRefsDialog,
+  WebSocketsManager
 } from './';
 
 export const App = ({ classes, location }) => (
@@ -22,6 +23,7 @@ export const App = ({ classes, location }) => (
     <CreateMapDialog />
     <AppendSegmentDialog />
     <SelectRefsDialog location={location} />
+    <WebSocketsManager />
   </div>
 );
 

--- a/packages/agent-ui/src/containers/index.js
+++ b/packages/agent-ui/src/containers/index.js
@@ -19,3 +19,4 @@ export { default as CreateMapDialog } from './createMapDialog';
 export { default as AppendSegmentDialog } from './appendSegmentDialog';
 export { default as SelectRefsDialog } from './selectRefsDialog';
 export { default as RefChipList } from './refChipList';
+export { default as WebSocketsManager } from './webSocketsManager';

--- a/packages/agent-ui/src/containers/webSocketsManager.js
+++ b/packages/agent-ui/src/containers/webSocketsManager.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/packages/agent-ui/src/containers/webSocketsManager.js
+++ b/packages/agent-ui/src/containers/webSocketsManager.js
@@ -1,0 +1,47 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { openWebSocket, closeAllWebSockets } from '../utils/webSocketHelpers';
+import * as statusTypes from '../constants/status';
+
+// this component's sole purpose is to manage websockets
+// upon mounting and unmounting. On mount, we want to
+// re open ws with all exisiting agents in our state.
+// On unmount, we want to close all the opened ws.
+export class WebSocketsManager extends Component {
+  componentDidMount() {
+    const { webSocketUrls, dispatch } = this.props;
+    webSocketUrls.forEach(({ name, url }) =>
+      openWebSocket(name, url, dispatch)
+    );
+  }
+
+  componentWillUnmount() {
+    closeAllWebSockets();
+  }
+
+  render() {
+    return null;
+  }
+}
+
+WebSocketsManager.propTypes = {
+  webSocketUrls: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired
+    })
+  ).isRequired,
+  dispatch: PropTypes.func.isRequired
+};
+
+export const mapStateToProps = state => {
+  const { agents = {} } = state;
+  const webSocketUrls = Object.values(agents)
+    .filter(({ status }) => status === statusTypes.LOADED)
+    .map(({ name, url }) => ({ name, url }));
+  return { webSocketUrls };
+};
+
+export default connect(mapStateToProps)(WebSocketsManager);

--- a/packages/agent-ui/src/containers/webSocketsManager.test.js
+++ b/packages/agent-ui/src/containers/webSocketsManager.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import * as webSocket from '../utils/webSocketHelpers';
+import { mapStateToProps, WebSocketsManager } from './webSocketsManager';
+import * as statusTypes from '../constants/status';
+
+chai.use(sinonChai);
+
+describe('<WebSocketsManager />', () => {
+  let openStub;
+  let closeStub;
+
+  const requiredProps = {
+    dispatch: () => {},
+    webSocketUrls: []
+  };
+
+  beforeEach(() => {
+    openStub = sinon.stub(webSocket, 'openWebSocket');
+    closeStub = sinon.stub(webSocket, 'closeAllWebSockets');
+  });
+
+  afterEach(() => {
+    openStub.restore();
+    closeStub.restore();
+  });
+
+  it('renders null', () => {
+    const mgr = shallow(<WebSocketsManager {...requiredProps} />);
+    expect(mgr.getElement()).to.be.null;
+  });
+
+  it('open websockets on mount', () => {
+    shallow(
+      <WebSocketsManager
+        {...requiredProps}
+        webSocketUrls={[
+          { name: 'foo', url: 'bar' },
+          { name: 'bar', url: 'foo' }
+        ]}
+      />
+    );
+    expect(openStub.callCount).to.equal(2);
+    expect(openStub.getCall(0).args[0]).to.equal('foo');
+    expect(openStub.getCall(0).args[1]).to.equal('bar');
+  });
+
+  it('closes websockets on unmount', () => {
+    const mgr = shallow(<WebSocketsManager {...requiredProps} />);
+    mgr.unmount();
+    expect(closeStub.callCount).to.equal(1);
+  });
+
+  it('returns empty webSocketUrls on empty state', () => {
+    expect(mapStateToProps({})).to.deep.equal({ webSocketUrls: [] });
+  });
+
+  it('extracts only loaded agents', () => {
+    const state = {
+      agents: {
+        foo: { status: statusTypes.LOADED, name: 'foo', url: 'http://foo' },
+        bar: { status: statusTypes.FAILED, name: 'bar', url: 'http://bar' }
+      }
+    };
+    const { webSocketUrls } = mapStateToProps(state);
+    expect(webSocketUrls).to.have.lengthOf(1);
+    expect(webSocketUrls).to.deep.equal([{ name: 'foo', url: 'http://foo' }]);
+  });
+});

--- a/packages/agent-ui/src/utils/notificationHelpers.js
+++ b/packages/agent-ui/src/utils/notificationHelpers.js
@@ -1,12 +1,23 @@
 import { v4 as uuid } from 'uuid';
 
+import * as notificationTypes from '../constants/notificationTypes';
+
 export const makeNotification = args => ({
   key: uuid(),
   ...args
 });
 
-export const makeNewSegmentNotification = (agent, process, segment) => {
-  // extract mapId and linkHash
-  const { link: { meta: { mapId } }, meta: { linkHash } } = segment;
-  return makeNotification({ agent, process, mapId, linkHash });
+export const makeNewSegmentNotification = segment => {
+  // extract info from segment
+  const {
+    link: { meta: { mapId, process } },
+    meta: { agentUrl, linkHash }
+  } = segment;
+  return makeNotification({
+    agentUrl,
+    process,
+    mapId,
+    linkHash,
+    type: notificationTypes.NEW_SEGMENT
+  });
 };

--- a/packages/agent-ui/src/utils/notificationHelpers.test.js
+++ b/packages/agent-ui/src/utils/notificationHelpers.test.js
@@ -1,9 +1,9 @@
-import 'babel-polyfill';
 import { expect } from 'chai';
 import {
   makeNotification,
   makeNewSegmentNotification
 } from './notificationHelpers';
+import * as notificationTypes from '../constants/notificationTypes';
 
 describe('notification helpers', () => {
   it('makeNotification() generates a new notification object with uuid', () => {
@@ -14,21 +14,21 @@ describe('notification helpers', () => {
   });
 
   it('makeNewSegmentNotification() adds agent info', () => {
-    const agent = 'foo';
+    const agentUrl = 'foo';
     const process = 'bar';
     const mapId = 'foo/bar';
     const linkHash = 'xyz';
-    const obj = {
-      agent,
-      process,
-      segment: {
-        link: { meta: { mapId } },
-        meta: { linkHash }
-      }
+    const segment = {
+      link: { meta: { mapId, process } },
+      meta: { linkHash, agentUrl }
     };
-    const { key, ...fromObj } = makeNewSegmentNotification(
-      ...Object.values(obj)
-    );
-    expect(fromObj).to.deep.equal({ agent, process, mapId, linkHash });
+    const { key, ...fromObj } = makeNewSegmentNotification(segment);
+    expect(fromObj).to.deep.equal({
+      agentUrl,
+      process,
+      mapId,
+      linkHash,
+      type: notificationTypes.NEW_SEGMENT
+    });
   });
 });

--- a/packages/agent-ui/src/utils/webSocketHelpers.js
+++ b/packages/agent-ui/src/utils/webSocketHelpers.js
@@ -1,0 +1,38 @@
+import { makeNewSegmentNotification } from './notificationHelpers';
+import { addNotifications } from '../actions';
+
+let webSockets = {};
+
+export const openWebSocket = (name, url, dispatch) => {
+  const wsUrl = url.replace('http', 'ws');
+  const { [name]: prevWS } = webSockets;
+  if (prevWS) {
+    prevWS.close();
+  }
+  const ws = new WebSocket(wsUrl);
+
+  ws.onmessage = payload => {
+    try {
+      const { type, data } = JSON.parse(payload.data);
+      if (type === 'didSave') {
+        dispatch(addNotifications([makeNewSegmentNotification(data)]));
+      }
+    } catch (e) {
+      // do nothing
+    }
+  };
+  webSockets = { ...webSockets, [name]: ws };
+};
+
+export const closeWebSocket = name => {
+  const { [name]: ws, ...rest } = webSockets;
+  if (ws) {
+    ws.close();
+  }
+  webSockets = rest;
+};
+
+export const closeAllWebSockets = () => {
+  Object.values(webSockets).forEach(ws => ws.close());
+  webSockets = {};
+};

--- a/packages/agent-ui/src/utils/webSocketHelpers.js
+++ b/packages/agent-ui/src/utils/webSocketHelpers.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import { makeNewSegmentNotification } from './notificationHelpers';
 import { addNotifications } from '../actions';
 

--- a/packages/agent-ui/src/utils/webSocketHelpers.test.js
+++ b/packages/agent-ui/src/utils/webSocketHelpers.test.js
@@ -1,0 +1,130 @@
+import { Server } from 'mock-socket';
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import {
+  openWebSocket,
+  closeWebSocket,
+  closeAllWebSockets
+} from './webSocketHelpers';
+
+chai.use(sinonChai);
+
+describe('webSocket actions', () => {
+  let mockServer;
+  let dispatchSpy;
+  let closeSpy;
+
+  // execute cb then delay a timeout (default to 5ms)
+  const delay = (cb, timeout = 5) => {
+    cb();
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve();
+      }, timeout);
+    });
+  };
+
+  beforeEach(() => {
+    mockServer = new Server('ws://foo/bar');
+    dispatchSpy = sinon.spy();
+    closeSpy = sinon.spy();
+  });
+
+  afterEach(() => {
+    mockServer.stop();
+    closeAllWebSockets();
+  });
+
+  describe('openWebSocket()', () => {
+    it('opens a ws for valid url', () => {
+      openWebSocket('myWS', 'http://foo/bar');
+      expect(mockServer.clients()).to.have.lengthOf(1);
+    });
+
+    it('does not open a ws for invalid url', () => {
+      openWebSocket('myWS', 'http://not/a/url');
+      expect(mockServer.clients()).to.have.lengthOf(0);
+    });
+
+    it('closes previously opened ws', () =>
+      // we use a delay hack here since the mock-socket library
+      // also uses a delay hack.. we can't capture the close call
+      // in the same tick because of that. timeout must be >= 4.
+      // https://github.com/thoov/mock-socket/blob/9fc37773a7b95f944aaffc5aac449b57dc4f037b/src/helpers/delay.js#L1
+      delay(() => {
+        openWebSocket('myWS', 'http://foo/bar');
+        const [ws] = mockServer.clients();
+        ws.onclose = closeSpy;
+      })
+        .then(() => openWebSocket('myWS', 'http://foo/bar'))
+        .then(() => {
+          expect(closeSpy.callCount).to.equal(1);
+        }));
+
+    it('dispatches a notification action on didSave message', () => {
+      openWebSocket('myWS', 'http://foo/bar', dispatchSpy);
+      const msg = {
+        type: 'didSave',
+        data: {
+          link: { meta: {} },
+          meta: {}
+        }
+      };
+      mockServer.send(JSON.stringify(msg));
+      expect(dispatchSpy.callCount).to.equal(1);
+    });
+
+    it('doesnt dispatch an action on other messages', () => {
+      openWebSocket('myWS', 'http://foo/bar', dispatchSpy);
+      const msg = {
+        type: 'foo/msg',
+        data: {
+          link: { meta: {} },
+          meta: {}
+        }
+      };
+      mockServer.send(JSON.stringify(msg));
+      mockServer.send('this msg will be disregarded');
+      expect(dispatchSpy.callCount).to.equal(0);
+    });
+  });
+
+  describe('closeWebSocket()', () => {
+    it('correctly closes a websocket', () =>
+      // same hack
+      delay(() => {
+        openWebSocket('myWS', 'http://foo/bar');
+        const [ws] = mockServer.clients();
+        ws.onclose = closeSpy;
+      })
+        .then(() => closeWebSocket('myWS'))
+        .then(() => {
+          expect(closeSpy.callCount).to.equal(1);
+        }));
+
+    it('does not fail to close unknown ws', () => {
+      expect(() => closeWebSocket('myWS')).to.not.throw();
+    });
+  });
+
+  describe('closeAllWebSockets', () => {
+    it('closes all websockets', () => {
+      // same hack
+      delay(() => openWebSocket('myWS1', 'http://foo/bar'))
+        .then(() => openWebSocket('myWS1', 'http://foo/bar'))
+        .then(() => {
+          const clients = mockServer.clients();
+          expect(clients).to.have.lengthOf(2);
+          clients.forEach(ws => {
+            ws.onclose = closeSpy;
+          });
+        })
+        .then(() => {
+          closeAllWebSockets();
+          expect(closeSpy.callCount).to.equal(2);
+        });
+    });
+  });
+});

--- a/packages/agent-ui/yarn.lock
+++ b/packages/agent-ui/yarn.lock
@@ -4623,6 +4623,10 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
+mock-socket@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-7.1.0.tgz#482ecccafb0f0e86b8905ba2aa57c1fe73ba262d"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
We open a websocket for each agent in the state. This websocket can dispatch new notification on `didSave` message that will make the `mapexplorer` refresh if someone else added a new segment.

At the moment, 2 notifications are disptached when I add a new segment: 1 from the appendSegment action and 1 from the websocket message we receive on didSave event. It all happens in the same tick so it does not refresh twice but we should fix this IMO.

We could rely on the didSave notification only to refresh the mapexplorer but I don't think it is very reliable, as it can be delayed (if consensus takes long time for ex..). It would be better to have a way to uniquely identify notifications (hash instead of uuid?) and check if we've already seen it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/169)
<!-- Reviewable:end -->
