### PR TITLE
ci: fix path for global deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
+  - export PATH=$HOME/.yarn/bin:$PATH
   - sh -e /etc/init.d/xvfb start
 before_script:
   - yarn global add codecov


### PR DESCRIPTION
yarn global librairies have been removed from the PATH in travis, it needs to be added manually.

another solution would be to add the codecov dependencies in `package.json`...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/176)
<!-- Reviewable:end -->
