### PR TITLE
agent, agent-client: stop rendering errors as links

### DIFF
--- a/packages/agent-client-js/src/request.js
+++ b/packages/agent-client-js/src/request.js
@@ -24,9 +24,7 @@ function send(method, url, args) {
     request({ method, url, body: args }, (err, res) => {
       if (err) {
         const error =
-          err && err.body && err.body.meta && err.body.meta.errorMessage
-            ? new Error(err.body.meta.errorMessage)
-            : err;
+          err && err.body && err.body.error ? new Error(err.body.error) : err;
         error.status = err.status;
         reject(error);
       } else {

--- a/packages/agent-js/src/error.js
+++ b/packages/agent-js/src/error.js
@@ -24,26 +24,11 @@ export default function error() {
     /* eslint-enable */
     if (err.status && err.status !== 500) {
       console.error(`${req.originalUrl}: ${err.stack}`);
-
-      if (res.locals.renderErrorAsLink) {
-        res
-          .status(err.status)
-          .json({ link: {}, meta: { errorMessage: err.message } });
-      } else {
-        res.status(err.status).json({ status: err.status, error: err.message });
-      }
-
+      res.status(err.status).json({ status: err.status, error: err.message });
       return;
     }
 
     console.error(`${req.originalUrl}: ${err.stack}`);
-
-    if (res.locals.renderErrorAsLink) {
-      res
-        .status(500)
-        .json({ link: {}, meta: { errorMessage: 'internal server error' } });
-    } else {
-      res.status(500).json({ status: 500, error: 'internal server error' });
-    }
+    res.status(500).json({ status: 500, error: 'internal server error' });
   };
 }

--- a/packages/agent-js/src/httpServer.js
+++ b/packages/agent-js/src/httpServer.js
@@ -365,13 +365,11 @@ export default function httpServer(agent, opts = {}) {
   app.post(
     '/:process/segments',
     loadProcess,
-    wrap((req, res) => {
-      res.locals.renderErrorAsLink = true;
-
-      return res.locals.process
+    wrap((req, res) =>
+      res.locals.process
         .createMap(...parseArgs(req.body))
-        .then(res.json.bind(res));
-    })
+        .then(res.json.bind(res))
+    )
   );
 
   /**
@@ -413,17 +411,15 @@ export default function httpServer(agent, opts = {}) {
   app.post(
     '/:process/segments/:linkHash/:action',
     loadProcess,
-    wrap((req, res) => {
-      res.locals.renderErrorAsLink = true;
-
-      return res.locals.process
+    wrap((req, res) =>
+      res.locals.process
         .createSegment(
           req.params.linkHash,
           req.params.action,
           ...parseArgs(req.body)
         )
-        .then(res.json.bind(res));
-    })
+        .then(res.json.bind(res))
+    )
   );
 
   /**


### PR DESCRIPTION
I discussed this with @stephan83 and there is no specific reason to format errors as links anymore.
The agent-client-ruby needs to be updated as well (I'm on it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/178)
<!-- Reviewable:end -->
