### PR TITLE
agent-ui: fetches stale agents on startup

### DIFF
--- a/packages/agent-ui/src/constants/status.js
+++ b/packages/agent-ui/src/constants/status.js
@@ -1,3 +1,4 @@
 export const LOADING = 'LOADING';
 export const FAILED = 'FAILED';
 export const LOADED = 'LOADED';
+export const STALE = 'STALE';

--- a/packages/agent-ui/src/containers/agentsPage.js
+++ b/packages/agent-ui/src/containers/agentsPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -9,31 +9,43 @@ import { getAgent, removeAgent } from '../actions';
 import { AgentsManager } from '../components';
 import * as statusTypes from '../constants/status';
 
-export const AgentsPage = ({ agents, fetchAgent, deleteAgent }) => (
-  <div style={{ padding: '1em' }}>
-    <Typography type="display1">Agents</Typography>
-    <Typography paragraph>
-      An agent executes the logic of your processes. A process is defined by a
-      set of actions that may be used in the workflow. An instance of a process
-      is called a map. It contains the different steps of the process, called
-      segments.
-    </Typography>
-    {(!agents || agents.length === 0) && (
-      <Typography>
-        It looks like you are not connected to any agent right now. Enter a name
-        and an url to connect to an agent. If you are running an agent locally,
-        it will usually be on http://localhost:3000
-      </Typography>
-    )}
-    {agents && (
-      <AgentsManager
-        agents={agents}
-        addAgent={fetchAgent}
-        deleteAgent={deleteAgent}
-      />
-    )}
-  </div>
-);
+export class AgentsPage extends Component {
+  componentDidMount() {
+    const { agents, fetchAgent } = this.props;
+    agents
+      .filter(({ status }) => status === statusTypes.STALE)
+      .forEach(({ name, url }) => fetchAgent(name, url));
+  }
+
+  render() {
+    const { agents, fetchAgent, deleteAgent } = this.props;
+    return (
+      <div style={{ padding: '1em' }}>
+        <Typography type="display1">Agents</Typography>
+        <Typography paragraph>
+          An agent executes the logic of your processes. A process is defined by
+          a set of actions that may be used in the workflow. An instance of a
+          process is called a map. It contains the different steps of the
+          process, called segments.
+        </Typography>
+        {(!agents || agents.length === 0) && (
+          <Typography>
+            It looks like you are not connected to any agent right now. Enter a
+            name and an url to connect to an agent. If you are running an agent
+            locally, it will usually be on http://localhost:3000
+          </Typography>
+        )}
+        {agents && (
+          <AgentsManager
+            agents={agents}
+            addAgent={fetchAgent}
+            deleteAgent={deleteAgent}
+          />
+        )}
+      </div>
+    );
+  }
+}
 
 AgentsPage.defaultProps = {
   agents: []
@@ -50,10 +62,11 @@ AgentsPage.propTypes = {
 };
 
 export function mapStateToProps(state) {
-  const agents = Object.keys(state.agents || [])
+  const agents = Object.keys(state.agents)
     .filter(
       a =>
         state.agents[a].status === statusTypes.LOADED ||
+        state.agents[a].status === statusTypes.STALE ||
         state.agents[a].status === statusTypes.FAILED
     )
     .map(a => ({

--- a/packages/agent-ui/src/reducers/agents.js
+++ b/packages/agent-ui/src/reducers/agents.js
@@ -1,3 +1,4 @@
+import { REHYDRATE } from 'redux-persist';
 import * as actionTypes from '../constants/actionTypes';
 import * as statusTypes from '../constants/status';
 
@@ -60,6 +61,13 @@ export default function(state = {}, action) {
     case actionTypes.AGENT_INFO_DELETE: {
       const { [agentName]: thisAgent, ...otherAgents } = state;
       return { ...otherAgents };
+    }
+    case REHYDRATE: {
+      const { payload: { agents } } = action;
+      return Object.keys(agents).reduce((newState, a) => {
+        const { [a]: { url } } = agents;
+        return { ...newState, [a]: { url, status: statusTypes.STALE } };
+      }, {});
     }
     default:
       return state;

--- a/packages/agent-ui/src/reducers/agents.test.js
+++ b/packages/agent-ui/src/reducers/agents.test.js
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
-
+import { REHYDRATE } from 'redux-persist';
 import agents from './agents';
 import * as actionTypes from '../constants/actionTypes';
 import * as statusTypes from '../constants/status';
 
 import { TestProcessBuilder, TestAgentBuilder } from '../test/builders/api';
+import { stat } from 'fs';
 
 describe('agents reducer', () => {
   it('returns previous state for unknown action', () => {
@@ -187,5 +188,34 @@ describe('agents reducer', () => {
       name: 'foobar'
     });
     expect(newState).to.deep.equal({ foo: {}, bar: {} });
+  });
+
+  it('change status to STALE on REHYDRATE', () => {
+    const state = {
+      foo: {
+        status: 'foo',
+        url: 'foo/url',
+        dummy: true
+      },
+      bar: {
+        status: 'bar',
+        url: 'bar/url',
+        nothing: false
+      }
+    };
+    const newState = agents(state, {
+      type: REHYDRATE,
+      payload: { agents: state }
+    });
+    expect(newState).to.deep.equal({
+      foo: {
+        status: statusTypes.STALE,
+        url: 'foo/url'
+      },
+      bar: {
+        status: statusTypes.STALE,
+        url: 'bar/url'
+      }
+    });
   });
 });

--- a/packages/agent-ui/src/reducers/agents.test.js
+++ b/packages/agent-ui/src/reducers/agents.test.js
@@ -5,7 +5,6 @@ import * as actionTypes from '../constants/actionTypes';
 import * as statusTypes from '../constants/status';
 
 import { TestProcessBuilder, TestAgentBuilder } from '../test/builders/api';
-import { stat } from 'fs';
 
 describe('agents reducer', () => {
   it('returns previous state for unknown action', () => {


### PR DESCRIPTION
On REHYDRATE (redux-persist action) we set all the agents that have been persisted to STALE. I have not found a good way to always persist the agents as STALE, so instead I do this on rehydrate.

The AgentsManager is in charge of fetching the info for all stale agents, on mount.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/182)
<!-- Reviewable:end -->
