### PR TITLE
agent-ui: handle empty redux-persist payload

### DIFF
--- a/packages/agent-ui/src/reducers/agents.js
+++ b/packages/agent-ui/src/reducers/agents.js
@@ -63,6 +63,8 @@ export default function(state = {}, action) {
       return { ...otherAgents };
     }
     case REHYDRATE: {
+      if (!action.payload) return state;
+
       const { payload: { agents } } = action;
       return Object.keys(agents).reduce((newState, a) => {
         const { [a]: { url } } = agents;

--- a/packages/agent-ui/src/reducers/agents.test.js
+++ b/packages/agent-ui/src/reducers/agents.test.js
@@ -189,6 +189,18 @@ describe('agents reducer', () => {
     expect(newState).to.deep.equal({ foo: {}, bar: {} });
   });
 
+  it('handles REHYDRATE with empty payload', () => {
+    const state = {
+      foo: {},
+      bar: {}
+    };
+    const newState = agents(state, {
+      type: REHYDRATE,
+      payload: undefined
+    });
+    expect(newState).to.deep.equal(state);
+  });
+
   it('change status to STALE on REHYDRATE', () => {
     const state = {
       foo: {


### PR DESCRIPTION
When no agent has ever been added to the UI, the REYDRATE action payload
is empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/186)
<!-- Reviewable:end -->
