### PR TITLE
agent-ui: mark agent and process as optional in SelectRefsDialog

### DIFF
--- a/packages/agent-ui/src/containers/selectRefsDialog.js
+++ b/packages/agent-ui/src/containers/selectRefsDialog.js
@@ -92,8 +92,8 @@ export class SelectRefsDialog extends Component {
 }
 
 SelectRefsDialog.propTypes = {
-  agent: PropTypes.string.isRequired,
-  process: PropTypes.string.isRequired,
+  agent: PropTypes.string,
+  process: PropTypes.string,
   processes: PropTypes.arrayOf(PropTypes.string).isRequired,
   fetchSegments: PropTypes.func.isRequired,
   closeDialog: PropTypes.func.isRequired,
@@ -110,6 +110,11 @@ SelectRefsDialog.propTypes = {
       })
     )
   }).isRequired
+};
+
+SelectRefsDialog.defaultProps = {
+  agent: '',
+  process: ''
 };
 
 function mapStateToProps(state, ownProps) {


### PR DESCRIPTION
They used to be marked as required even though the Dialog is included in
the page when none is available.

Closes #173 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/187)
<!-- Reviewable:end -->
