### PR TITLE
agent-ui: use alpine to reduce docker image size

### DIFF
--- a/packages/agent-ui/Dockerfile
+++ b/packages/agent-ui/Dockerfile
@@ -1,6 +1,4 @@
-FROM node:8
-
-RUN npm install -g yarn
+FROM node:8-alpine
 
 RUN mkdir /agent-ui
 ADD package.json /agent-ui/package.json
@@ -12,5 +10,5 @@ WORKDIR /agent-ui
 ENV NODE_ENV production
 RUN yarn build
 
-RUN npm install -g serve
+RUN yarn global add serve
 CMD serve -s build -p 4000


### PR DESCRIPTION
Uncompressed to size goes from ~900MB to ~500MB

No additional apk package seems to be necesssary. Only the `fsevents` dependency fails to be installed but I don't think it's a big deal inside that Docker image.

If we wanted to install it we'd have to add:
`RUN apk add --no-cache git make gcc g++`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/198)
<!-- Reviewable:end -->
