### PR TITLE
agent-js: update PATH with npm binaries in Docker

### DIFF
--- a/packages/agent-js/Dockerfile.development
+++ b/packages/agent-js/Dockerfile.development
@@ -2,7 +2,7 @@ FROM node:8.9.1
 
 RUN mkdir /src
 
-RUN npm install -g mocha@^2.5.3 nodemon@^1.9.2 should@^10.0.0
+ENV PATH "$PATH:/src/node_modules/.bin"
 
 ONBUILD ADD package.json /src/package.json
 ONBUILD RUN cd /src; npm install

--- a/packages/agent-js/Dockerfile.development.alpine
+++ b/packages/agent-js/Dockerfile.development.alpine
@@ -4,7 +4,7 @@ RUN apk add --no-cache git make gcc g++ python
 
 RUN mkdir /src
 
-RUN npm install -g mocha@^2.5.3 nodemon@^1.9.2 should@^10.0.0
+ENV PATH "$PATH:/src/node_modules/.bin"
 
 ONBUILD ADD package.json /src/package.json
 ONBUILD RUN cd /src; npm install


### PR DESCRIPTION
To optimize the caching performed by Docker, we first copy the
package.json to the Docker image and install the dependencies. We then
use a mounted volume for all the src files and the actual package.json
from which we run the npm commands. Since this package.json is not at
the same level where the dependencies were installed, it isn't aware of
the available binaries. We use to install these dependencies globally to
work around this issue, but it is slower at build time and adds
duplication.
We chose instead to update the PATH so that is takes into account the
"local" dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/204)
<!-- Reviewable:end -->
