### PR TITLE
react-mapexplorer: use updated style

### DIFF
--- a/packages/react-mapexplorer/src/mapExplorerCss.js
+++ b/packages/react-mapexplorer/src/mapExplorerCss.js
@@ -17,13 +17,14 @@ const linkTextFont = 'Gibson-Regular, Montserrat, sans-serif';
 
 export function getRules() {
   const brandPrimary = '#EC714A';
-  const segmentPrimaryColor = '#7BC0D2';
-  const segmentSecondaryColor = '#459FB7';
+
+  const segmentPrimaryColor = '#293047';
+  const segmentSecondaryColor = '#040406';
   const segmentTextColor = 'white';
   const segmentTextFont = '"RationalTWText-SemiBold", "Roboto Mono", monospace';
 
-  const selectedSegmentPrimaryColor = '#3E3E3E';
-  const selectedSegmentSecondaryColor = '#2E2E2E';
+  const selectedSegmentPrimaryColor = '#2be4a6';
+  const selectedSegmentSecondaryColor = '#13966a';
 
   const foreignSegmentPrimaryColor = '#CD5C5C';
   const foreignSegmentSecondaryColor = '#8B0000';


### PR DESCRIPTION
I don't know whether we should merge it before the release (it would make the tutorials screenshot out of date even though that's not a huge deal...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/206)
<!-- Reviewable:end -->
