### PR TITLE
agent-ui: disable ui caching for form arguments

### DIFF
--- a/packages/agent-ui/src/components/actionArgumentFields.js
+++ b/packages/agent-ui/src/components/actionArgumentFields.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { v4 as uuid } from 'uuid';
 
 import TextField from 'material-ui/TextField';
 
 export const ActionArgumentFields = ({ args, valueChanged }) =>
   args.map((arg, index) => (
     <TextField
-      key={arg}
+      key={uuid()}
       label={arg}
       onChange={e => {
         valueChanged(index, e.target.value);


### PR DESCRIPTION
Since the key was the args name, React didn't re-render previous form content.
So there was a mismatch between the state and what the UI showed.

#209

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/212)
<!-- Reviewable:end -->
