### PR TITLE
agent-ui: properly handle refresh on all routes

### DIFF
--- a/packages/agent-ui/src/containers/agentsPage.js
+++ b/packages/agent-ui/src/containers/agentsPage.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -9,43 +9,31 @@ import { getAgent, removeAgent } from '../actions';
 import { AgentsManager } from '../components';
 import * as statusTypes from '../constants/status';
 
-export class AgentsPage extends Component {
-  componentDidMount() {
-    const { agents, fetchAgent } = this.props;
-    agents
-      .filter(({ status }) => status === statusTypes.STALE)
-      .forEach(({ name, url }) => fetchAgent(name, url));
-  }
-
-  render() {
-    const { agents, fetchAgent, deleteAgent } = this.props;
-    return (
-      <div style={{ padding: '1em' }}>
-        <Typography type="display1">Agents</Typography>
-        <Typography paragraph>
-          An agent executes the logic of your processes. A process is defined by
-          a set of actions that may be used in the workflow. An instance of a
-          process is called a map. It contains the different steps of the
-          process, called segments.
-        </Typography>
-        {(!agents || agents.length === 0) && (
-          <Typography>
-            It looks like you are not connected to any agent right now. Enter a
-            name and an url to connect to an agent. If you are running an agent
-            locally, it will usually be on http://localhost:3000
-          </Typography>
-        )}
-        {agents && (
-          <AgentsManager
-            agents={agents}
-            addAgent={fetchAgent}
-            deleteAgent={deleteAgent}
-          />
-        )}
-      </div>
-    );
-  }
-}
+export const AgentsPage = ({ agents, fetchAgent, deleteAgent }) => (
+  <div style={{ padding: '1em' }}>
+    <Typography type="display1">Agents</Typography>
+    <Typography paragraph>
+      An agent executes the logic of your processes. A process is defined by a
+      set of actions that may be used in the workflow. An instance of a process
+      is called a map. It contains the different steps of the process, called
+      segments.
+    </Typography>
+    {(!agents || agents.length === 0) && (
+      <Typography>
+        It looks like you are not connected to any agent right now. Enter a name
+        and an url to connect to an agent. If you are running an agent locally,
+        it will usually be on http://localhost:3000
+      </Typography>
+    )}
+    {agents && (
+      <AgentsManager
+        agents={agents}
+        addAgent={fetchAgent}
+        deleteAgent={deleteAgent}
+      />
+    )}
+  </div>
+);
 
 AgentsPage.defaultProps = {
   agents: []

--- a/packages/agent-ui/src/containers/agentsPage.test.js
+++ b/packages/agent-ui/src/containers/agentsPage.test.js
@@ -34,18 +34,6 @@ describe('<AgentsPage />', () => {
     );
   });
 
-  it('fetches all the staled agents', () => {
-    const agents = [
-      { name: 'foo', url: 'foo/url', status: statusTypes.LOADED },
-      { name: 'bar', url: 'bar/url', status: statusTypes.STALE },
-      { name: 'stale', url: 'stale/url', status: statusTypes.STALE }
-    ];
-    mount(<AgentsPage {...requiredProps} agents={agents} />);
-    expect(fetchSpy.callCount).to.equal(2);
-    expect(fetchSpy.getCall(0).args).to.deep.equal(['bar', 'bar/url']);
-    expect(fetchSpy.getCall(1).args).to.deep.equal(['stale', 'stale/url']);
-  });
-
   it('extracts loaded agents from state', () => {
     const loadedAgent1 = new TestAgentBuilder()
       .withStatus(statusTypes.LOADED)

--- a/packages/agent-ui/src/containers/leftNavigation.js
+++ b/packages/agent-ui/src/containers/leftNavigation.js
@@ -67,7 +67,7 @@ const AgentNavigationLinks = ({ agents, agent, process }) => (
     {agents.map(a => (
       <div key={a.name} id={a.name}>
         <AgentNavigationLink text={a.name} to={`/${a.name}`} />
-        <Collapse in={!!(agent && a.name === agent)} transitionDuration="auto">
+        <Collapse in={!!(agent && a.name === agent)}>
           <List disablePadding>
             {a.processes.map(p => (
               <div key={p}>
@@ -76,10 +76,7 @@ const AgentNavigationLinks = ({ agents, agent, process }) => (
                   to={`/${a.name}/${p}`}
                   margin="1em"
                 />
-                <Collapse
-                  in={!!(process && p === process)}
-                  transitionDuration="auto"
-                >
+                <Collapse in={!!(process && p === process)}>
                   <AgentNavigationLink
                     text="maps"
                     to={`/${a.name}/${p}/maps`}

--- a/packages/agent-ui/src/containers/webSocketsManager.js
+++ b/packages/agent-ui/src/containers/webSocketsManager.js
@@ -44,6 +44,12 @@ WebSocketsManager.propTypes = {
 };
 
 export const mapStateToProps = state => {
+  if (!state.agents) {
+    return {
+      agents: []
+    };
+  }
+
   const agents = Object.keys(state.agents)
     .filter(
       a =>


### PR DESCRIPTION
The main issue was that only the agents page (/) handled loading the agents.
It should be the responsibility of the web sockets manager : 
* When the app mounts, all agents have been loaded from the persisted state and are STALE
* So we should fetch each one of them, which will open a web socket as well
* At the end of the app's life, we should close those web sockets

Resolves #214 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/216)
<!-- Reviewable:end -->
