### PR TITLE
client-js: remove first slash

### DIFF
--- a/packages/agent-client-js/src/httpAdaptor.js
+++ b/packages/agent-client-js/src/httpAdaptor.js
@@ -29,35 +29,35 @@ export default class httpAdaptor {
   }
 
   getProcesses() {
-    return get(url.resolve(this.url, '/processes'));
+    return get(url.resolve(this.url, 'processes'));
   }
 
   createMap(processName, refs, ...args) {
-    return post(url.resolve(this.url, `/${processName}/segments`), [
+    return post(url.resolve(this.url, `${processName}/segments`), [
       refs,
       ...args
     ]);
   }
 
   getSegment(processName, linkHash) {
-    return get(url.resolve(this.url, `/${processName}/segments/${linkHash}`));
+    return get(url.resolve(this.url, `${processName}/segments/${linkHash}`));
   }
 
   findSegments(processName, opts = {}) {
     return get(
-      url.resolve(this.url, `/${processName}/segments${makeQueryString(opts)}`)
+      url.resolve(this.url, `${processName}/segments${makeQueryString(opts)}`)
     );
   }
 
   getMapIds(processName, opts = {}) {
     return get(
-      url.resolve(this.url, `/${processName}/maps${makeQueryString(opts)}`)
+      url.resolve(this.url, `${processName}/maps${makeQueryString(opts)}`)
     );
   }
 
   createSegment(processName, linkHash, action, refs, ...args) {
     return post(
-      url.resolve(this.url, `/${processName}/segments/${linkHash}/${action}`),
+      url.resolve(this.url, `${processName}/segments/${linkHash}/${action}`),
       [refs, ...args]
     );
   }


### PR DESCRIPTION
At the moment, if `agentUrl=http://something/agent`, then doing a `findSegments` ends up fetching: `http://something/process/segments` instead of `http://something/agent/process/segments`. This is how `url.resolve` works.

removing first slash solves this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/indigo-js/234)
<!-- Reviewable:end -->
